### PR TITLE
CompatHelper: add new compat entry for Mocking at version 0.7, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,9 @@ JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 LibPQ = "194296ae-ab2e-5f79-8cd4-7183a0a5a0d1"
 Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 
+[compat]
+Mocking = "0.7"
+
 [extras]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"


### PR DESCRIPTION
This pull request sets the compat entry for the `Mocking` package to `0.7`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.