### PR TITLE
CompatHelper: add new compat entry for DotEnv at version 1, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,11 +13,14 @@ JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 LibPQ = "194296ae-ab2e-5f79-8cd4-7183a0a5a0d1"
 LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 
+[compat]
+DotEnv = "1"
+
 [extras]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 
 [targets]
 test = ["Test", "Logging", "Revise", "Mocking", "LoggingExtras", "LibPQ", "Dates", "DataFrames", "DotEnv", "HTTP", "JSON3"]


### PR DESCRIPTION
This pull request sets the compat entry for the `DotEnv` package to `1`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.