### PR TITLE
Fix CI workflow project activation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,60 +1,61 @@
 name: CI
 on:
-  push:
-    branches:
-      - main
-    tags: ['*']
-  pull_request:
-  workflow_dispatch:
+    push:
+        branches:
+            - main
+        tags: ["*"]
+    pull_request:
+    workflow_dispatch:
 jobs:
-  test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    env:
-      TIINGO_API_KEY: ${{ secrets.TIINGO_API_KEY || 'mock-api-key-for-testing' }}
-      JULIA_NUM_THREADS: 'auto'
-    permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
-      actions: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - '1.9'
-          - '1.10'
-          - 'nightly'
-        os:
-          - ubuntu-latest
-          - macos-latest
-        arch:
-          - x64
-        # Exclude nightly from macOS to speed up CI
-        exclude:
-          - os: macos-latest
-            version: 'nightly'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-      - name: Setup test environment
-        run: |
-          # Create .env file for testing
-          echo "TIINGO_API_KEY=$TIINGO_API_KEY" > .env
-          # Create test directory for DuckDB temp files
-          mkdir -p .duckdb_temp
-      - name: Install dependencies
-        run: julia -e 'import Pkg; Pkg.instantiate()'
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          coverage: true
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v4
-        with:
-          file: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+    test:
+        name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+        runs-on: ${{ matrix.os }}
+        timeout-minutes: 60
+        env:
+            TIINGO_API_KEY: ${{ secrets.TIINGO_API_KEY || 'mock-api-key-for-testing' }}
+            JULIA_NUM_THREADS: "auto"
+            JULIA_PROJECT: "."
+        permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
+            actions: write
+            contents: read
+        strategy:
+            fail-fast: false
+            matrix:
+                version:
+                    - "1.9"
+                    - "1.10"
+                    - "nightly"
+                os:
+                    - ubuntu-latest
+                    - macos-latest
+                arch:
+                    - x64
+                # Exclude nightly from macOS to speed up CI
+                exclude:
+                    - os: macos-latest
+                      version: "nightly"
+        steps:
+            - uses: actions/checkout@v4
+            - uses: julia-actions/setup-julia@v2
+              with:
+                  version: ${{ matrix.version }}
+                  arch: ${{ matrix.arch }}
+            - uses: julia-actions/cache@v2
+            - uses: julia-actions/julia-buildpkg@v1
+            - name: Setup test environment
+              run: |
+                  # Create .env file for testing
+                  echo "TIINGO_API_KEY=$TIINGO_API_KEY" > .env
+                  # Create test directory for DuckDB temp files
+                  mkdir -p .duckdb_temp
+            - name: Install dependencies
+              run: julia --project=. -e 'import Pkg; Pkg.instantiate(); Pkg.precompile()'
+            - uses: julia-actions/julia-runtest@v1
+              with:
+                  coverage: true
+            - uses: julia-actions/julia-processcoverage@v1
+            - uses: codecov/codecov-action@v4
+              with:
+                  file: lcov.info
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- update CI workflow to always activate the project
- precompile deps when installing

## Testing
- `pre-commit run --files .github/workflows/CI.yml`

------
https://chatgpt.com/codex/tasks/task_e_685aa7b9cb7c832eba4330d1fc12d31a