### PR TITLE
Fix CI: use direct Pkg.test instead of julia-actions/julia-runtest to ensure all dependencies are available

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,9 +52,9 @@ jobs:
               run: |
                   julia --project=. -e 'import Pkg; Pkg.instantiate(); Pkg.resolve(); Pkg.precompile()'
                   julia --project=. -e 'using TimeSeries; println("TimeSeries loaded successfully")'
-            - uses: julia-actions/julia-runtest@v1
-              with:
-                  coverage: true
+            - name: Verify test environment
+              run: |
+                  julia --project=. -e 'import Pkg; Pkg.test(;coverage=true)'
             - uses: julia-actions/julia-processcoverage@v1
             - uses: codecov/codecov-action@v4
               with:


### PR DESCRIPTION
<!--
Thanks for making a pull request to TiingoJulia.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines and abide by the code of conduct.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [ ] I am following the [contributing guidelines](https://github.com/10kpw/TiingoJulia/blob/main/docs/src/90-contributing.md)

- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
