### PR TITLE
Fix get_api_key error handling

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -48,7 +48,7 @@ function get_api_key()::String
     end
 
     api_key = get(ENV, APIConfig.API_KEY_NAME, nothing)
-    if isnothing(api_key)
+    if isnothing(api_key) || isempty(api_key)
         available_keys = join(keys(ENV), ", ")
         error("""
             $(APIConfig.API_KEY_NAME) not found in environment variables.


### PR DESCRIPTION
## Summary
- ensure `get_api_key` raises an error if the key value is empty

## Testing
- `julia --project=. test/runtests.jl` *(fails: `julia` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e74f4992c832e8299e8fc9d7886e1