### PR TITLE
Fix get_api_key env loading

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -21,10 +21,13 @@ end
 Load environment variables from .env file.
 Returns true if successful, false otherwise.
 """
+const _ENV_LOADED = Ref(false)
+
 function load_env_file(env_path::String)::Bool
     try
-        if isfile(env_path)
+        if !_ENV_LOADED[] && isfile(env_path)
             DotEnv.load!(env_path)
+            _ENV_LOADED[] = true
             return true
         end
         return false


### PR DESCRIPTION
## Summary
- avoid repeatedly loading the `.env` file in `load_env_file`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_685e7cb2c7cc832e985dc9ba9c0b0aa9