### PR TITLE
Fix failing DB tests

### DIFF
--- a/test/test_db.jl
+++ b/test/test_db.jl
@@ -119,6 +119,18 @@ end
 """,
         )
 
+        # Refresh filtered tickers table after inserting
+        DBInterface.execute(
+            conn,
+            """
+CREATE OR REPLACE TABLE us_tickers_filtered AS
+SELECT * FROM us_tickers
+WHERE exchange IN ('NYSE', 'NASDAQ', 'NYSE ARCA', 'AMEX', 'ASX')
+  AND assetType IN ('Stock', 'ETF')
+  AND ticker NOT LIKE '%/%'
+""",
+        )
+
         # Test retrieving tickers
         all_tickers = get_tickers_all(conn)
         @test nrow(all_tickers) > 0


### PR DESCRIPTION
## Summary
- refresh `us_tickers_filtered` table in db tests

## Testing
- `julia --project=. test/runtests.jl` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec117a990832e8451fa33f77276b0