### PR TITLE
ci: drop hardcoded x64 arch for Apple Silicon macOS runner

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
     workflow_dispatch:
 jobs:
     test:
-        name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+        name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
         runs-on: ${{ matrix.os }}
         timeout-minutes: 60
         env:
@@ -26,18 +26,16 @@ jobs:
                 os:
                     - ubuntu-latest
                     - macos-latest
-                arch:
-                    - x64
-                # Exclude nightly from macOS to speed up CI
-                exclude:
-                    - os: macos-latest
-                      version: "nightly"
+                # arch is auto-detected by julia-actions/setup-julia based on
+                # the runner OS (ubuntu-latest -> x64, macos-latest -> aarch64).
+                # Hardcoding `x64` broke macos-latest after GitHub migrated the
+                # default macOS runner to Apple Silicon.
         steps:
             - uses: actions/checkout@v6
             - uses: julia-actions/setup-julia@v3
               with:
                   version: ${{ matrix.version }}
-                  arch: ${{ matrix.arch }}
+                  # arch omitted; setup-julia auto-detects the runner architecture.
             - name: Validate release hygiene
               run: |
                   julia --project=. scripts/ci/validate_release_hygiene.jl


### PR DESCRIPTION
## Summary

GitHub migrated the default `macos-latest` runner to Apple Silicon (arm64). The current matrix hardcodes `arch: [x64]`, which makes `setup-julia@v3` error out on the macOS leg with:

\`\`\`
[setup-julia] x64 arch has been requested on a macOS runner that has an arm64 (Apple Silicon) architecture.
\`\`\`

## Fix

Drop the `arch` matrix dimension entirely. \`setup-julia@v3\` auto-detects the runner architecture from the OS (ubuntu-latest → x86_64, macos-latest → aarch64), which is exactly what we want.

Three coordinated edits in \`.github/workflows/CI.yml\`:

- Line 11: remove \`\${{ matrix.arch }}\` from the job-name template (otherwise it expands to empty, leaving an awkward double-dash).
- Lines 26-32: remove \`arch: [x64]\` from the matrix; replace with explanatory comment.
- Lines 35-38: remove \`arch: \${{ matrix.arch }}\` input from the \`setup-julia@v3\` step.

The dead \`exclude\` rule for \`macos-latest\` × \`nightly\` is also dropped since the matrix doesn't include \`nightly\` — it was a no-op.

## Test Plan

- [ ] CI green on \`ubuntu-latest\` (Julia 1.10, x86_64 auto-detect)
- [ ] CI green on \`macos-latest\` (Julia 1.10, aarch64 auto-detect)
- [ ] Job name in Actions UI shows \`Julia 1.10 - macos-latest - pull_request\` (no double-dash)

## Why this PR is small

Targeted at the architecture-mismatch issue only. Other CI improvements (adding Julia 1.11 to the matrix, updating to \`actions/checkout@v6\`, etc.) are intentionally deferred to follow-up PRs to keep this change reviewable.