### PR TITLE
fix: make staging smoke test droplet-ready

### DIFF
--- a/scripts/run_staging_smoke.sh
+++ b/scripts/run_staging_smoke.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-REPO_DIR="/Users/otwn/Documents/TiingoJulia"
+REPO_DIR="${TIINGO_REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 ENV_FILE="${TIINGO_ENV_FILE:-$REPO_DIR/.env.staging}"
 
 cd "$REPO_DIR"

--- a/scripts/staging_smoke_test.jl
+++ b/scripts/staging_smoke_test.jl
@@ -33,7 +33,7 @@ function main()
     max_concurrent = parse_int_env("TIINGO_SMOKE_MAX_CONCURRENT", 5)
     use_parallel = parse_bool_env("TIINGO_SMOKE_USE_PARALLEL", false)
     export_postgres = parse_bool_env("TIINGO_SMOKE_EXPORT_POSTGRES", false)
-    pg_connection_string = strip(get(ENV, "TIINGO_PG_CONNECTION", ""))
+    pg_connection_string = String(strip(get(ENV, "TIINGO_PG_CONNECTION", "")))
 
     if ticker_limit < 1
         throw(ArgumentError("TIINGO_SMOKE_TICKER_LIMIT must be >= 1"))


### PR DESCRIPTION
## Problem

Running `scripts/run_staging_smoke.sh` on a droplet completed the full ticker download and DuckDB write (52,702 historical rows) but crashed at the final PostgreSQL export:

```
ERROR: MethodError: no method matching connect_postgres(::SubString{String})
  @ scripts/staging_smoke_test.jl:93
```

Two issues blocked the smoke test from running on a droplet:

1. **Type dispatch.** `strip(get(ENV, "TIINGO_PG_CONNECTION", ""))` returns a `SubString{String}`, but `connect_postgres(::String)` and `export_to_postgres(...; pg_connection_string::Union{Nothing,String})` are typed for concrete `String`, so dispatch fails before the export runs. The same variable is also passed to `export_to_postgres` (line 98), so fixing only the first call site would surface the same error next.
2. **Hardcoded macOS path.** `run_staging_smoke.sh` hardcoded `REPO_DIR=/Users/otwn/Documents/TiingoJulia` and `cd`'d into it. The droplet only worked via a manual local edit (repo drift), which `git pull` would clobber. The `/Users/otwn/` path also trips the private-path scan in `scripts/sync_public_cherry_pick.sh`, breaking the public sync.

## Changes

- `staging_smoke_test.jl`: wrap the connection string in `String(...)` so it matches both call sites. The library API in `src/db/postgres.jl` is intentionally left untouched — its `::String` contract is consistent across the module.
- `run_staging_smoke.sh`: derive `REPO_DIR` from the script's own location, with a `TIINGO_REPO_DIR` override. Runs unmodified on mac and both droplets, and removes the private path.

## Verification

- `String(strip(...))` confirmed to produce `::String` (matches `connect_postgres(::String)`).
- `bash -n scripts/run_staging_smoke.sh` passes; `REPO_DIR` resolves to the repo root.
- Private-path scan (`otwn|/Users/|...`) finds nothing in either touched file, so both pass the public sync.
- ⏳ Pending: re-run `bash scripts/run_staging_smoke.sh` on the 10kpw preprod droplet to confirm the export against the local `postgres:17.5` (127.0.0.1:5433) now completes.

## Notes

- Based on `main` to keep this a focused two-file change. The `chore: add public sync helper` commit on `feature/my-change` is intentionally excluded.
- Part of making the staging smoke path production-ready across the preprod (10kpw.com) and prod (TokusenQuant.com) droplets. The macOS `launchd` plist still hardcodes a path and is macOS-only; a Linux systemd timer / cron for droplet scheduling is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
