### PR TITLE
fix(docs): deploy via GITHUB_TOKEN instead of DOCUMENTER_KEY

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -28,5 +28,4 @@ jobs:
             - name: Build and deploy docs
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
               run: julia --color=yes --project=docs docs/make.jl


### PR DESCRIPTION
## Problem

The `Documentation` workflow builds the docs successfully but fails at the final `deploydocs` step:

```
git@github.com: Permission denied (publickey).
Error: Git failed to fetch git@github.com:10kpw/TiingoJulia
This can be caused by a DOCUMENTER_KEY variable that is not correctly set up.
```

`deploydocs` prefers `DOCUMENTER_KEY` (SSH) over `GITHUB_TOKEN` when both are present. The secret is set, but its public half is no longer registered as a write-access deploy key on `10kpw/TiingoJulia` — most likely a casualty of the recent repo rename (`tiingo_julia` → `TiingoJulia`) / public split. Because `DOCUMENTER_KEY` is non-empty, Documenter uses SSH and never falls back to the token, so CI fails at deploy.

## Change

Drop `DOCUMENTER_KEY` from the workflow `env`. The job already grants `permissions: contents: write` and passes `GITHUB_TOKEN`, so `deploydocs` now pushes to the same repo's `gh-pages` over HTTPS with the Actions token. No deploy-key or secret setup required.

```diff
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
               run: julia --color=yes --project=docs docs/make.jl
```

## Verification

- Workflow YAML re-parsed OK after the edit; `env` now exposes only `GITHUB_TOKEN`, and `contents: write` is intact.
- `gh-pages` branch already exists (docs deployed here before), so GitHub Pages "deploy from branch" will publish the token push.

## Notes / caveats

- This relies on Pages serving from the `gh-pages` branch. If Pages is later switched to a "GitHub Actions" source, a `GITHUB_TOKEN` push won't trigger the Pages build and we'd revisit.
- `10kpw/TiingoJulia` is private; GitHub Pages only *serves* private-repo sites on paid plans. The push will now succeed regardless, but if the site doesn't render, the docs likely belong on the public `Quansift` repo instead — a separate decision.
- Non-fatal build warnings are intentionally out of scope here and can be a follow-up: `makedocs(repo=...)` passed as a string (navbar repo-URL warning), an invalid `../../README.md` link in `docs/src/PERFORMANCE.md`, and 41 docstrings not included in the manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
