### PR TITLE
feat(deploy): containerize pipeline for droplet deployment via GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,50 @@
+name: Publish image
+
+# Builds the production image and pushes it to GHCR so droplets can pull
+# (instead of building Julia/precompile on a memory-constrained droplet).
+# Tags: branch name (e.g. `staging`, `main`), `sha-<short>`, version on git tags,
+# and `latest` on main.
+on:
+    push:
+        branches:
+            - main
+            - staging
+        tags: ["*"]
+    workflow_dispatch:
+
+jobs:
+    build-push:
+        name: Build and push to GHCR
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            - uses: actions/checkout@v6
+            - uses: docker/setup-buildx-action@v3
+            - name: Log in to GHCR
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Derive image tags
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ghcr.io/${{ github.repository_owner }}/tiingojulia
+                  tags: |
+                      type=ref,event=branch
+                      type=ref,event=tag
+                      type=sha
+                      type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            - name: Build and push
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  file: docker/Dockerfile
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,72 @@
+# Droplet deployment (containerized pipeline)
+
+The TiingoJulia pipeline runs as a **oneshot container** joined to the DB stack's
+shared Docker network, scheduled by a systemd timer. The image is built and pushed
+to GHCR by CI, so the droplet only pulls (no heavy Julia precompile on the droplet).
+
+Environment tiers (same image, config-only difference):
+
+| Domain | Role | Host | Image tag | Env file |
+|--------|------|------|-----------|----------|
+| 10kpw.com | preprod | `10kpw-non-prod` | `staging` | `.env.staging` |
+| TokusenQuant.com | prod | — | `latest` (or version) | `.env` |
+
+## One-time setup on a droplet
+
+1. **Clone / place the repo** at `/opt/tiingojulia` (or edit `WorkingDirectory` in the
+   systemd unit to point at your checkout).
+
+2. **Authenticate to GHCR** so the droplet can pull the (private) image:
+
+   ```bash
+   echo "$GHCR_PAT" | docker login ghcr.io -u <github-user> --password-stdin
+   ```
+
+   `GHCR_PAT` is a GitHub PAT with `read:packages`. (Or make the GHCR package public,
+   then no login is needed.)
+
+3. **Create the env file** at the repo root. The PG host must be the **in-network
+   alias on port 5432** (not the host-published `127.0.0.1:5433`):
+
+   ```dotenv
+   TIINGO_API_KEY=...
+   TIINGO_PG_CONNECTION=postgresql://USER:PASS@postgres:5432/DB?sslmode=disable
+   TIINGO_SMOKE_EXPORT_POSTGRES=true
+   ```
+
+   Preprod aliases that resolve on `db-net`: `postgres`, `postgres_db`, `pdb`.
+
+4. **Smoke test the container** (verifies the whole path, incl. the PostgreSQL export):
+
+   ```bash
+   docker compose -f deploy/compose/docker-compose.pipeline.yml run --rm pipeline
+   ```
+
+   Expect `Staging PostgreSQL export completed`.
+
+## Schedule with systemd
+
+```bash
+sudo cp deploy/systemd/tiingojulia-pipeline.service /etc/systemd/system/
+sudo cp deploy/systemd/tiingojulia-pipeline.timer   /etc/systemd/system/
+# edit WorkingDirectory in the .service if not using /opt/tiingojulia
+sudo systemctl daemon-reload
+sudo systemctl enable --now tiingojulia-pipeline.timer
+systemctl list-timers tiingojulia-pipeline.timer   # confirm next run
+journalctl -u tiingojulia-pipeline.service -f      # follow run logs
+```
+
+## preprod → prod promotion
+
+Same files. On the prod droplet: set `TIINGO_IMAGE_TAG` (e.g. `latest`), provide the
+prod `.env` (TIINGO_ENV_FILE), and confirm the prod DB stack's external network name
+matches `db-net` (edit the compose `networks:` block if it differs).
+
+## Notes / follow-ups
+
+- The scheduled command is currently `scripts/staging_smoke_test.jl` (a real but
+  ticker-limited sync + PG export). A full production-sync entrypoint under `scripts/`
+  is a follow-up; point the compose `command:` at it when it lands.
+- DuckDB runs in ephemeral `/tmp` (the authoritative store is PostgreSQL). If a
+  persistent local DuckDB is needed later, add a `/data` volume plus a Dockerfile
+  `mkdir -p /data && chown appuser /data`.

--- a/deploy/compose/docker-compose.pipeline.yml
+++ b/deploy/compose/docker-compose.pipeline.yml
@@ -1,0 +1,38 @@
+# TiingoJulia data pipeline — oneshot run on the shared DB network.
+#
+# Run on a droplet (from the repo root):
+#   docker compose -f deploy/compose/docker-compose.pipeline.yml run --rm pipeline
+#
+# Requires:
+#   - The external Docker network the DB stack exposes (preprod: `db-net`).
+#   - An env file at the repo root (preprod: `.env.staging`) providing
+#     TIINGO_API_KEY and TIINGO_PG_CONNECTION. The PG host MUST be the
+#     in-network service alias on port 5432 (e.g. postgres:5432 / postgres_db:5432),
+#     NOT the host-published 127.0.0.1:5433. SSL is typically off in-network:
+#       TIINGO_PG_CONNECTION=postgresql://USER:PASS@postgres:5432/DB?sslmode=disable
+#       TIINGO_SMOKE_EXPORT_POSTGRES=true
+#
+# Image tag and env file are overridable:
+#   TIINGO_IMAGE_TAG=latest TIINGO_ENV_FILE=../../.env docker compose -f ... run --rm pipeline
+
+services:
+    pipeline:
+        image: ghcr.io/10kpw/tiingojulia:${TIINGO_IMAGE_TAG:-staging}
+        # ENTRYPOINT is `julia --project=/app`; this is the script it runs.
+        # Swap for the full-sync entrypoint once one exists under scripts/.
+        command: ["scripts/staging_smoke_test.jl"]
+        env_file:
+            - ${TIINGO_ENV_FILE:-../../.env.staging}
+        environment:
+            # DuckDB is local working state; the authoritative store is PostgreSQL.
+            # Keep it in writable, ephemeral /tmp so the non-root container user can write.
+            TIINGO_DB_PATH: /tmp/tiingo.duckdb
+            TIINGO_DUCKDB_TMP: /tmp
+        networks:
+            - db-net
+        restart: "no"
+
+networks:
+    # Provided by the DB stack; not created by this compose file.
+    db-net:
+        external: true

--- a/deploy/systemd/tiingojulia-pipeline.service
+++ b/deploy/systemd/tiingojulia-pipeline.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=TiingoJulia data pipeline (oneshot container run)
+Documentation=https://github.com/10kpw/TiingoJulia
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# Point this at the repo checkout on the droplet (or symlink the checkout here).
+WorkingDirectory=/opt/tiingojulia
+ExecStart=/usr/bin/docker compose -f deploy/compose/docker-compose.pipeline.yml pull pipeline
+ExecStart=/usr/bin/docker compose -f deploy/compose/docker-compose.pipeline.yml run --rm pipeline
+TimeoutStartSec=1800
+
+# Installed/triggered by tiingojulia-pipeline.timer; no [Install] section here
+# so it is not enabled to run on its own.

--- a/deploy/systemd/tiingojulia-pipeline.timer
+++ b/deploy/systemd/tiingojulia-pipeline.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run the TiingoJulia data pipeline daily
+Documentation=https://github.com/10kpw/TiingoJulia
+
+[Timer]
+# Daily at 06:00 (matches the previous macOS launchd schedule). Adjust as needed.
+OnCalendar=*-*-* 06:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Containerizes the TiingoJulia data pipeline for droplet deployment. The pipeline runs as a **oneshot container joined to the DB stack's shared `db-net` network**, scheduled by a systemd timer, with the image **built and pushed to GHCR by CI** so the (memory-constrained, ~3 GB) droplet only pulls — no Julia precompile on the droplet.

This implements the "container execution model" chosen for the preprod (10kpw.com) → prod (TokusenQuant.com) tiers; promotion is config-only (same image, different `.env`).

## Files added (all net-new; no Dockerfile change)

- **`.github/workflows/docker-publish.yml`** — build + push image to `ghcr.io/10kpw/tiingojulia` on push to `main`/`staging` and tags (`staging`, `main`, `sha-…`, `latest` on main). The existing CI build step stays as PR build-verification.
- **`deploy/compose/docker-compose.pipeline.yml`** — oneshot `pipeline` service on the external `db-net`. Reaches Postgres by in-network alias on **port 5432** (`postgres`/`postgres_db`/`pdb`), not the host-published `127.0.0.1:5433`. DuckDB runs in ephemeral `/tmp` (authoritative store is PostgreSQL). Image tag and env file are overridable.
- **`deploy/systemd/tiingojulia-pipeline.{service,timer}`** — daily run (06:00) via `docker compose run --rm` with journald logging.
- **`deploy/README.md`** — droplet one-time setup (GHCR login, env file, in-network connection string), smoke test, systemd install, and preprod→prod promotion.

## Why this addresses the earlier failures

- `connect_postgres` MethodError (#563) — already fixed; confirmed reaching the real connection on the droplet.
- "could not translate host name postgres_db" — root cause was running native Julia on the host (outside Docker DNS). In a container on `db-net`, `postgres_db:5432` resolves. Confirmed: the postgres container carries aliases `postgres`, `postgres_db`, `pdb` on `db-net` and `10kpw-db-preprod_db_private`.

## Validation

- `docker-publish.yml` and `docker-compose.pipeline.yml` parse as valid YAML.
- `docker compose config` renders the merged config correctly (command, env_file resolution, `/tmp` overrides, external `db-net`, GHCR image tag).
- systemd: service is `Type=oneshot` (pull then run), timer carries `[Install]`.

## Follow-ups (out of scope)

- The scheduled command is `scripts/staging_smoke_test.jl` (a real but ticker-limited sync + PG export). A full production-sync entrypoint under `scripts/` is a follow-up — point the compose `command:` at it when it exists.
- Persistent local DuckDB (a `/data` volume + Dockerfile `chown appuser`) if needed later.
- GHCR package visibility/auth: droplet needs `docker login ghcr.io` (PAT with `read:packages`) unless the package is made public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
