### PR TITLE
fix: pass DataFrame directly to LibPQ.load! in PostgreSQL export

### DIFF
--- a/src/db/postgres.jl
+++ b/src/db/postgres.jl
@@ -336,7 +336,7 @@ module Postgres
             insert_query = "INSERT INTO $staging_name ($columns) VALUES ($placeholders)"
 
             LibPQ.load!(
-                (col => df[!, col] for col in names(df)),
+                df,
                 pg_conn,
                 insert_query
             )


### PR DESCRIPTION
The DataFrames export path passed a generator of `col => vector` Pairs to LibPQ.load!, which interprets each Pair as a 2-field row. For a 6-column table this produced "bind message supplies 2 parameters, but prepared statement requires 6". Pass the DataFrame (a Tables.jl source) directly so columns bind positionally to the INSERT placeholders.


Claude-Session: https://claude.ai/code/session_0178rjosHPfSQ34NF77q9S93

<!--
Thanks for making a pull request to TiingoJulia.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines and abide by the code of conduct.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [ ] I am following the [contributing guidelines](https://github.com/10kpw/TiingoJulia/blob/main/docs/src/90-contributing.md)

- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
