### PR TITLE
fix: FK-safe in-place upsert for PostgreSQL export (us_tickers_filtered)

### DIFF
--- a/src/db/postgres.jl
+++ b/src/db/postgres.jl
@@ -130,22 +130,124 @@ module Postgres
         LibPQ.execute(pg_conn, "DROP TABLE IF EXISTS $safe_name;")
     end
 
+    """
+        is_fk_referenced(pg_conn, table_name) -> Bool
+
+    Check whether `table_name` is referenced by any foreign key constraint
+    from another table (i.e. it is the *parent* / referenced side).
+    """
+    function is_fk_referenced(pg_conn::PostgreSQLConnection, table_name::String)::Bool
+        safe_name = validate_identifier(table_name)
+        result = LibPQ.execute(pg_conn, """
+            SELECT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE contype = 'f'
+                  AND confrelid = '$safe_name'::regclass
+            )
+        """)
+        df = DataFrame(result)
+        return df[1, 1]
+    end
+
+    """
+        get_primary_key_columns(pg_conn, table_name) -> Vector{String}
+
+    Return the column names that form the primary key of `table_name`,
+    looked up from the PostgreSQL catalog.
+    """
+    function get_primary_key_columns(pg_conn::PostgreSQLConnection, table_name::String)::Vector{String}
+        safe_name = validate_identifier(table_name)
+        result = LibPQ.execute(pg_conn, """
+            SELECT a.attname
+            FROM pg_index i
+            JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+            WHERE i.indrelid = '$safe_name'::regclass
+              AND i.indisprimary
+            ORDER BY a.attnum
+        """)
+        df = DataFrame(result)
+        return String.(df[!, :attname])
+    end
+
     function replace_postgres_table!(pg_conn::PostgreSQLConnection, target_table::String, staging_table::String)
         safe_target = validate_identifier(target_table)
         safe_staging = validate_identifier(staging_table)
 
-        LibPQ.execute(pg_conn, "BEGIN")
+        # Check if the target table exists and is referenced by foreign keys
+        target_exists = false
         try
-            LibPQ.execute(pg_conn, "DROP TABLE IF EXISTS $safe_target;")
-            LibPQ.execute(pg_conn, "ALTER TABLE $safe_staging RENAME TO $safe_target;")
-            LibPQ.execute(pg_conn, "COMMIT")
-        catch e
-            try
-                LibPQ.execute(pg_conn, "ROLLBACK")
-            catch
+            res = LibPQ.execute(pg_conn, """
+                SELECT EXISTS (
+                    SELECT 1 FROM information_schema.tables
+                    WHERE table_schema = 'public' AND table_name = '$safe_target'
+                )
+            """)
+            target_exists = DataFrame(res)[1, 1]
+        catch
+        end
+
+        fk_referenced = target_exists && is_fk_referenced(pg_conn, safe_target)
+
+        if fk_referenced
+            # Upsert path: refresh in-place to preserve dependent FK constraints
+            pk_cols = get_primary_key_columns(pg_conn, safe_target)
+            if isempty(pk_cols)
+                error("Table $safe_target is referenced by foreign keys but has no primary key; " *
+                      "an upsert key is required to refresh in-place without dropping the table")
             end
-            @error "Failed to atomically replace PostgreSQL table" target_table=safe_target staging_table=safe_staging exception=(e, catch_backtrace())
-            rethrow(e)
+
+            # Get column list from the staging table
+            col_result = LibPQ.execute(pg_conn, """
+                SELECT column_name FROM information_schema.columns
+                WHERE table_schema = 'public' AND table_name = '$safe_staging'
+                ORDER BY ordinal_position
+            """)
+            all_cols = String.(DataFrame(col_result)[!, :column_name])
+            non_pk_cols = filter(c -> !(c in pk_cols), all_cols)
+
+            cols_sql = join(all_cols, ", ")
+            pk_sql = join(pk_cols, ", ")
+            update_sql = join(["$c = EXCLUDED.$c" for c in non_pk_cols], ", ")
+
+            upsert_query = if isempty(non_pk_cols)
+                "INSERT INTO $safe_target ($cols_sql) SELECT $cols_sql FROM $safe_staging ON CONFLICT ($pk_sql) DO NOTHING"
+            else
+                "INSERT INTO $safe_target ($cols_sql) SELECT $cols_sql FROM $safe_staging ON CONFLICT ($pk_sql) DO UPDATE SET $update_sql"
+            end
+
+            @info "Table $safe_target is FK-referenced; using upsert instead of drop+rename"
+            LibPQ.execute(pg_conn, "BEGIN")
+            try
+                LibPQ.execute(pg_conn, upsert_query)
+                LibPQ.execute(pg_conn, "DROP TABLE IF EXISTS $safe_staging;")
+                LibPQ.execute(pg_conn, "COMMIT")
+            catch e
+                try
+                    LibPQ.execute(pg_conn, "ROLLBACK")
+                catch
+                end
+                try
+                    drop_postgres_table_if_exists(pg_conn, safe_staging)
+                catch
+                end
+                @error "Failed to upsert into FK-referenced PostgreSQL table" target_table=safe_target staging_table=safe_staging exception=(e, catch_backtrace())
+                rethrow(e)
+            end
+        else
+            # Fast path: drop + rename (no FK dependents)
+            LibPQ.execute(pg_conn, "BEGIN")
+            try
+                LibPQ.execute(pg_conn, "DROP TABLE IF EXISTS $safe_target;")
+                LibPQ.execute(pg_conn, "ALTER TABLE $safe_staging RENAME TO $safe_target;")
+                LibPQ.execute(pg_conn, "COMMIT")
+            catch e
+                try
+                    LibPQ.execute(pg_conn, "ROLLBACK")
+                catch
+                end
+                @error "Failed to atomically replace PostgreSQL table" target_table=safe_target staging_table=safe_staging exception=(e, catch_backtrace())
+                rethrow(e)
+            end
         end
     end
 


### PR DESCRIPTION
## Summary

Refresh foreign-key-referenced tables in-place via upsert in the PostgreSQL export path, instead of the destructive `DROP + RENAME` swap. This fixes the export of `us_tickers_filtered`, which is referenced by `filtered_stocks.filtered_stocks_ticker_fkey` and therefore cannot be dropped.

This is the one commit (`1fdf3b8`) still missing from `main` after PR #574 (which already brought the related `LibPQ.load!` fix).

## Change

`replace_postgres_table!` now:
- Detects whether the target table is referenced by a foreign key (queries `pg_constraint`).
- **FK-referenced** → refresh in-place inside a transaction via `INSERT ... ON CONFLICT (pk) DO UPDATE`, using the target's primary key looked up from the catalog. Rows absent from staging are intentionally preserved (deleting them could violate the dependent FK). Table identity and dependent constraints are kept.
- **Not referenced** (e.g. `historical_data`, ~13M rows) → unchanged fast `DROP + RENAME` path.
- FK-referenced but no primary key → clear error instead of a silent destructive drop.

Only `src/db/postgres.jl` changes (111 insertions, 9 deletions).

## Validation

Verified end-to-end on preprod (10kpw) via the staging Docker image — full pipeline completed:

```
[ Info: Table us_tickers_filtered is FK-referenced; using upsert instead of drop+rename
[ Info: Inserted 12128 rows into PostgreSQL table us_tickers_filtered
[ Info: Successfully exported us_tickers_filtered from DuckDB to PostgreSQL
[ Info: Staging PostgreSQL export completed (historical_data, us_tickers_filtered)
```

`filtered_stocks` FK preserved; `historical_data` export unaffected.

## Why this matters for production

The scheduled pipeline (`quansift_scheduler`) depends on `TiingoJulia {rev = "main"}`. Without this on `main`, scheduled `*-export` runs hit `cannot drop table us_tickers_filtered because other objects depend on it`. After merge, run `Pkg.update("TiingoJulia")` in the scheduler env to pull the new commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)