### PR TITLE
refactor: provider-agnostic OHLCV env vars (backward-compatible)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,9 @@ TIINGO_API_KEY=your_tiingo_api_key
 # TIINGO_API_KEY_NAME=TIINGO_API_KEY
 # TIINGO_ENV_FILE=.env
 # TIINGO_CONFIG_PATH=./config.toml
-# TIINGO_DB_PATH=/data/tiingo_historical_data.duckdb
-# TIINGO_PG_CONNECTION=postgresql://user:password@host:5432/database?sslmode=require
+# OHLCV_DUCKDB_PATH=/data/tiingo_historical_data.duckdb
+# OHLCV_PG_CONNECTION=postgresql://user:password@host:5432/database?sslmode=require
+# Legacy aliases TIINGO_DB_PATH / DUCKDB_PATH / TIINGO_DUCKDB_PATH / TIINGO_PG_CONNECTION still honored.
 # TIINGO_LOG_FILE=./stock.log
 # TIINGO_LOGGER=console
 # TIINGO_API_BASE_URL=https://api.tiingo.com/tiingo/daily

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -3,7 +3,8 @@ TIINGO_API_KEY=replace_me_with_real_tiingo_api_key
 
 # Recommended runtime defaults
 TIINGO_LOGGER=console
-TIINGO_DB_PATH=/data/staging_smoke.duckdb
+OHLCV_DUCKDB_PATH=/data/staging_smoke.duckdb
+# Legacy aliases TIINGO_DB_PATH / DUCKDB_PATH / TIINGO_DUCKDB_PATH still honored.
 TIINGO_DUCKDB_TMP=./.duckdb_temp
 TIINGO_DUCKDB_MEMORY_LIMIT_GB=1
 TIINGO_DUCKDB_THREADS=1
@@ -13,7 +14,8 @@ TIINGO_DUCKDB_UPSERT_CHUNK_SIZE=500
 
 # Optional PostgreSQL export target.
 # For docker-networked droplets, prefer postgres:5432 with sslmode=disable.
-TIINGO_PG_CONNECTION=postgresql://user:password@host:5432/database?sslmode=require
+OHLCV_PG_CONNECTION=postgresql://user:password@host:5432/database?sslmode=require
+# Legacy alias TIINGO_PG_CONNECTION still honored.
 
 # Current scheduled entrypoint settings (bounded sync)
 TIINGO_SMOKE_TICKER_LIMIT=25

--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -35,7 +35,7 @@ and is easier to inspect than `cron` with `systemctl` and `journalctl`.
 1. Create a staging env file from [.env.staging.example](.env.staging.example).
 2. Or use the machine-specific `.env.staging` that lives in the repo root and fill in the placeholders.
 3. Set `TIINGO_API_KEY`.
-4. Set `TIINGO_PG_CONNECTION` only if you want to validate PostgreSQL export too.
+4. Set `OHLCV_PG_CONNECTION` (or legacy `TIINGO_PG_CONNECTION`) only if you want to validate PostgreSQL export too.
 5. Keep `TIINGO_SMOKE_EXPORT_POSTGRES=false` for the first run.
 6. Run the smoke test.
    Inline `TIINGO_SMOKE_*` overrides now take precedence over values in the env file:
@@ -46,16 +46,16 @@ TIINGO_SMOKE_TICKER_LIMIT=5 TIINGO_SMOKE_EXPORT_POSTGRES=false scripts/run_stagi
 
 The smoke test will:
 
-- Create or open the DuckDB file from `TIINGO_DB_PATH`
+- Create or open the DuckDB file from `OHLCV_DUCKDB_PATH` (or legacy `TIINGO_DB_PATH`)
 - Optimize and index the database
 - Download Tiingo ticker metadata
 - Pull a bounded set of historical prices using `TIINGO_SMOKE_TICKER_LIMIT`
 - Optionally export `historical_data` and `us_tickers_filtered` to PostgreSQL
 
-`TIINGO_DB_PATH` is the actual intermediate DuckDB file path.
+`OHLCV_DUCKDB_PATH` (or legacy `TIINGO_DB_PATH`) is the actual intermediate DuckDB file path.
 `TIINGO_DUCKDB_TMP` is separate and only controls DuckDB scratch space.
 The containerized deployment keeps scratch space and downloaded ticker temp files in `/tmp`
-but no longer overrides `TIINGO_DB_PATH`.
+but no longer overrides `OHLCV_DUCKDB_PATH`.
 On 3GB-class droplets, set `TIINGO_DUCKDB_MEMORY_LIMIT_GB=1`, `TIINGO_DUCKDB_THREADS=1`,
 `TIINGO_DUCKDB_WORKER_THREADS=1`, `TIINGO_DUCKDB_PRESERVE_INSERTION_ORDER=false`,
 and `TIINGO_DUCKDB_UPSERT_CHUNK_SIZE=500` in the app env file.
@@ -82,8 +82,8 @@ This repo ships Linux deployment assets for Docker + `systemd`:
 
 The current scheduled container command is still [`scripts/staging_smoke_test.jl`](scripts/staging_smoke_test.jl).
 Production scope is therefore controlled by `TIINGO_SMOKE_*` variables in the app env file.
-Container runs respect `TIINGO_DB_PATH` from the selected app env file.
-The compose file bind-mounts a host DuckDB directory into the container, so `TIINGO_DB_PATH`
+Container runs respect `OHLCV_DUCKDB_PATH` (or legacy `TIINGO_DB_PATH`) from the selected app env file.
+The compose file bind-mounts a host DuckDB directory into the container, so `OHLCV_DUCKDB_PATH`
 should point at the container-side mount location, such as `/data/tiingo_historical_data.duckdb`.
 
 ### 10kpw Preprod (`10kpw-non-prod`)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ TIINGO_API_KEY=your_api_key_here
 Use `config.example.toml` as a template if you want a custom config file per deployment.
 
 - `TIINGO_CONFIG_PATH`: path to an alternate `config.toml` (legacy `config.json` is still supported)
-- `TIINGO_DB_PATH`: default DuckDB path
+- `OHLCV_DUCKDB_PATH`: DuckDB file path (legacy aliases: `DUCKDB_PATH`, `TIINGO_DUCKDB_PATH`, `TIINGO_DB_PATH`)
 - `TIINGO_API_BASE_URL`: Tiingo daily base URL
 - `TIINGO_TICKERS_URL`: ticker zip URL
 - `TIINGO_API_MAX_RETRIES`: API retry attempts
@@ -131,7 +131,7 @@ The current Linux deployment path is:
 - `/etc/default/tiingojulia-pipeline` for host-side compose selection
 
 `cron` is not the recommended scheduler here. The repo ships `systemd` units and the pipeline depends on Docker plus an external DB network, which `systemd` manages more cleanly.
-`TIINGO_DB_PATH` is the intermediate DuckDB file path. `TIINGO_DUCKDB_TMP` is separate and only controls DuckDB scratch space.
+`OHLCV_DUCKDB_PATH` (or legacy `TIINGO_DB_PATH`) is the intermediate DuckDB file path. `TIINGO_DUCKDB_TMP` is separate and only controls DuckDB scratch space.
 On 3GB-class droplets, set `TIINGO_DUCKDB_MEMORY_LIMIT_GB=1`, `TIINGO_DUCKDB_THREADS=1`,
 `TIINGO_DUCKDB_WORKER_THREADS=1`, and keep `TIINGO_DUCKDB_PRESERVE_INSERTION_ORDER=false`.
 
@@ -150,7 +150,7 @@ The app env file should contain the variables you actually want inside the conta
 
 ```dotenv
 TIINGO_API_KEY=replace_me_with_real_tiingo_api_key
-TIINGO_PG_CONNECTION=postgresql://USER:PASS@postgres:5432/DB?sslmode=disable
+OHLCV_PG_CONNECTION=postgresql://USER:PASS@postgres:5432/DB?sslmode=disable
 TIINGO_LOGGER=console
 TIINGO_SMOKE_TICKER_LIMIT=25
 TIINGO_SMOKE_BATCH_SIZE=25
@@ -209,7 +209,7 @@ journalctl -u tiingojulia-pipeline.service -f
 Edit `/opt/tiingojulia/.env.staging` before the first run and set at least:
 
 - `TIINGO_API_KEY`
-- `TIINGO_PG_CONNECTION` if PostgreSQL export is enabled
+- `OHLCV_PG_CONNECTION` (or legacy `TIINGO_PG_CONNECTION`) if PostgreSQL export is enabled
 - `TIINGO_SMOKE_EXPORT_POSTGRES=true` when you want the export path validated
 
 For a bounded one-off Docker smoke run, pass overrides with `run -e`:
@@ -262,12 +262,23 @@ journalctl -u tiingojulia-pipeline.service -f
 Edit `/opt/tiingojulia/.env` before the first run and set:
 
 - `TIINGO_API_KEY`
-- `TIINGO_PG_CONNECTION`
-- `TIINGO_DB_PATH=/data/tiingo_historical_data.duckdb`
+- `OHLCV_PG_CONNECTION` (or legacy `TIINGO_PG_CONNECTION`)
+- `OHLCV_DUCKDB_PATH=/data/tiingo_historical_data.duckdb` (or legacy `TIINGO_DB_PATH`)
 - `TIINGO_SMOKE_EXPORT_POSTGRES=true`
 - `TIINGO_SMOKE_TICKER_LIMIT` to the production scope you actually want
 
 At the moment the scheduled container command is still [`scripts/staging_smoke_test.jl`](scripts/staging_smoke_test.jl), so production scope is controlled by `TIINGO_SMOKE_*` variables rather than a separate full-sync entrypoint.
+
+### OHLCV Environment Variables
+
+When run under the scheduler (systemd timer or launchd), TiingoJulia sources its own `.env` file (per-repo config ownership via `TIINGO_APP_ENV_FILE`).
+
+| Canonical name | Purpose | Legacy aliases (checked in order if canonical is unset) |
+|---|---|---|
+| `OHLCV_DUCKDB_PATH` | Filesystem path to the OHLCV/historical-price DuckDB | `DUCKDB_PATH`, `TIINGO_DUCKDB_PATH`, `TIINGO_DB_PATH` |
+| `OHLCV_PG_CONNECTION` | PostgreSQL connection string for the OHLCV/price database | `TIINGO_PG_CONNECTION` |
+
+All legacy aliases remain functional. Existing deployments using `TIINGO_DB_PATH` or `TIINGO_PG_CONNECTION` require no changes.
 
 ## Contributing
 
@@ -479,7 +490,7 @@ ORDER BY ticker, date
 df = DBInterface.execute(conn, query) |> DataFrame
 
 # Export to PostgreSQL
-pg_connection_string = ENV["TIINGO_PG_CONNECTION"]
+pg_connection_string = get(ENV, "OHLCV_PG_CONNECTION", ENV["TIINGO_PG_CONNECTION"])
 pg_conn = connect_postgres(pg_connection_string)
 export_to_postgres(
     conn,
@@ -549,10 +560,10 @@ TIINGO_API_KEY=your_actual_api_key_here
 TIINGO_LOGGER=console    # Default: "console". Options: "null", "console", "tee", "file", "tee-file"
 
 # Optional: PostgreSQL export connection
-TIINGO_PG_CONNECTION=postgresql://user:password@host:5432/database?sslmode=require
+OHLCV_PG_CONNECTION=postgresql://user:password@host:5432/database?sslmode=require
 
 # Optional: Database configuration
-TIINGO_DB_PATH=/path/to/your/preferred/database.duckdb
+OHLCV_DUCKDB_PATH=/path/to/your/preferred/database.duckdb
 
 # Current scheduled pipeline settings
 TIINGO_SMOKE_TICKER_LIMIT=25

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -30,7 +30,7 @@ Environment tiers (same image, config-only difference):
 
    ```dotenv
    TIINGO_API_KEY=...
-   TIINGO_PG_CONNECTION=postgresql://USER:PASS@postgres:5432/DB?sslmode=disable
+   OHLCV_PG_CONNECTION=postgresql://USER:PASS@postgres:5432/DB?sslmode=disable
    TIINGO_SMOKE_EXPORT_POSTGRES=true
    ```
 
@@ -106,7 +106,7 @@ If the prod Docker network differs, change `TIINGO_DOCKER_NETWORK` in
 - The scheduled command is currently `scripts/staging_smoke_test.jl` (a real but
   bounded sync + PG export). Control production scope with `TIINGO_SMOKE_*` variables
   in the selected app env file.
-- `TIINGO_DB_PATH` is the DuckDB file location and now comes directly from the
+- `OHLCV_DUCKDB_PATH` (or legacy `TIINGO_DB_PATH`) is the DuckDB file location and now comes directly from the
   selected app env file. `TIINGO_DUCKDB_TMP` is separate and only controls DuckDB
   scratch space. The compose file pins scratch space and downloaded ticker temp
   files to `/tmp` inside the container.
@@ -115,7 +115,7 @@ If the prod Docker network differs, change `TIINGO_DOCKER_NETWORK` in
   `TIINGO_DUCKDB_PRESERVE_INSERTION_ORDER=false`, and
   `TIINGO_DUCKDB_UPSERT_CHUNK_SIZE=500` in the app env file.
 - The compose file bind-mounts `TIINGO_DB_HOST_DIR` into `TIINGO_DB_CONTAINER_DIR`.
-  Set `TIINGO_DB_PATH` in the app env file to a path under that mounted container
+  Set `OHLCV_DUCKDB_PATH` in the app env file to a path under that mounted container
   directory, such as `/data/tiingo_historical_data.duckdb`.
 - If a persistent local DuckDB file is needed later, add a container volume for the
-  chosen `TIINGO_DB_PATH` location plus a writable directory owned by `appuser`.
+  chosen `OHLCV_DUCKDB_PATH` location plus a writable directory owned by `appuser`.

--- a/deploy/compose/docker-compose.pipeline.yml
+++ b/deploy/compose/docker-compose.pipeline.yml
@@ -14,7 +14,7 @@
 # Requires:
 #   - The external Docker network the DB stack exposes (preprod: `db-net`).
 #   - An env file at the repo root (preprod: `.env.staging`) providing
-#     TIINGO_API_KEY and TIINGO_PG_CONNECTION. The PG host MUST be the
+#     TIINGO_API_KEY and OHLCV_PG_CONNECTION (or legacy TIINGO_PG_CONNECTION). The PG host MUST be the
 #     in-network service alias on port 5432 (e.g. postgres:5432 / postgres_db:5432),
 #     NOT the host-published 127.0.0.1:5433. SSL is typically off in-network:
 #       TIINGO_PG_CONNECTION=postgresql://USER:PASS@postgres:5432/DB?sslmode=disable
@@ -32,7 +32,7 @@ services:
         env_file:
             - ${TIINGO_APP_ENV_FILE:-../../.env.staging}
         environment:
-            # Respect TIINGO_DB_PATH from the selected app env file.
+            # Respect OHLCV_DUCKDB_PATH (or legacy TIINGO_DB_PATH) from the selected app env file.
             # Only container-local scratch files are forced into /tmp.
             TIINGO_DUCKDB_TMP: /tmp
             TIINGO_TICKERS_ZIP: /tmp/supported_tickers.zip

--- a/scripts/run_staging_smoke.sh
+++ b/scripts/run_staging_smoke.sh
@@ -11,10 +11,10 @@ if [[ ! -f "$ENV_FILE" ]]; then
   exit 1
 fi
 
-# Preserve explicit TIINGO_* environment overrides supplied by the caller.
+# Preserve explicit TIINGO_* and OHLCV_* environment overrides supplied by the caller.
 EXISTING_TIINGO_ENV=()
 while IFS='=' read -r name _; do
-  if [[ "$name" == TIINGO_* ]] && [[ -n "${!name+x}" ]]; then
+  if [[ "$name" == TIINGO_* || "$name" == OHLCV_* ]] && [[ -n "${!name+x}" ]]; then
     EXISTING_TIINGO_ENV+=("$name=${!name}")
   fi
 done < <(env)
@@ -34,8 +34,10 @@ if [[ "${TIINGO_API_KEY:-}" == "replace_me_with_real_tiingo_api_key" || "${TIING
   exit 1
 fi
 
-if [[ "${TIINGO_SMOKE_EXPORT_POSTGRES:-false}" == "true" && "${TIINGO_PG_CONNECTION:-}" == "postgresql://user:password@host:5432/database?sslmode=require" ]]; then
-  echo "Set TIINGO_PG_CONNECTION in $ENV_FILE before enabling PostgreSQL export." >&2
+# Resolve PG connection: canonical OHLCV_PG_CONNECTION, then legacy TIINGO_PG_CONNECTION.
+_resolved_pg="${OHLCV_PG_CONNECTION:-${TIINGO_PG_CONNECTION:-}}"
+if [[ "${TIINGO_SMOKE_EXPORT_POSTGRES:-false}" == "true" && "$_resolved_pg" == "postgresql://user:password@host:5432/database?sslmode=require" ]]; then
+  echo "Set OHLCV_PG_CONNECTION (or TIINGO_PG_CONNECTION) in $ENV_FILE before enabling PostgreSQL export." >&2
   exit 1
 fi
 

--- a/scripts/staging_smoke_test.jl
+++ b/scripts/staging_smoke_test.jl
@@ -27,13 +27,19 @@ function parse_int_env(name::String, default::Int)::Int
 end
 
 function main()
-    db_path = abspath(get(ENV, "TIINGO_DB_PATH", joinpath(pwd(), "data", "staging_smoke.duckdb")))
+    # Canonical: OHLCV_DUCKDB_PATH; legacy aliases: DUCKDB_PATH, TIINGO_DUCKDB_PATH, TIINGO_DB_PATH
+    db_path = abspath(get(ENV, "OHLCV_DUCKDB_PATH",
+        get(ENV, "DUCKDB_PATH",
+            get(ENV, "TIINGO_DUCKDB_PATH",
+                get(ENV, "TIINGO_DB_PATH", joinpath(pwd(), "data", "staging_smoke.duckdb"))))))
     ticker_limit = parse_int_env("TIINGO_SMOKE_TICKER_LIMIT", 25)
     batch_size = parse_int_env("TIINGO_SMOKE_BATCH_SIZE", min(ticker_limit, 25))
     max_concurrent = parse_int_env("TIINGO_SMOKE_MAX_CONCURRENT", 5)
     use_parallel = parse_bool_env("TIINGO_SMOKE_USE_PARALLEL", false)
     export_postgres = parse_bool_env("TIINGO_SMOKE_EXPORT_POSTGRES", false)
-    pg_connection_string = String(strip(get(ENV, "TIINGO_PG_CONNECTION", "")))
+    # Canonical: OHLCV_PG_CONNECTION; legacy alias: TIINGO_PG_CONNECTION
+    pg_connection_string = String(strip(get(ENV, "OHLCV_PG_CONNECTION",
+        get(ENV, "TIINGO_PG_CONNECTION", ""))))
 
     if ticker_limit < 1
         throw(ArgumentError("TIINGO_SMOKE_TICKER_LIMIT must be >= 1"))
@@ -45,7 +51,7 @@ function main()
         throw(ArgumentError("TIINGO_SMOKE_MAX_CONCURRENT must be >= 1"))
     end
     if export_postgres && isempty(pg_connection_string)
-        throw(ArgumentError("TIINGO_PG_CONNECTION is required when TIINGO_SMOKE_EXPORT_POSTGRES=true"))
+        throw(ArgumentError("OHLCV_PG_CONNECTION (or legacy TIINGO_PG_CONNECTION) is required when TIINGO_SMOKE_EXPORT_POSTGRES=true"))
     end
 
     mkpath(dirname(db_path))

--- a/src/config.jl
+++ b/src/config.jl
@@ -129,7 +129,11 @@ module Config
 
     module DB
         import ..CONFIG, ..cfg_get
-        const DEFAULT_DUCKDB_PATH = get(ENV, "TIINGO_DB_PATH", "tiingo_historical_data.duckdb")
+        # Canonical: OHLCV_DUCKDB_PATH; legacy aliases: DUCKDB_PATH, TIINGO_DUCKDB_PATH, TIINGO_DB_PATH
+        const DEFAULT_DUCKDB_PATH = get(ENV, "OHLCV_DUCKDB_PATH",
+            get(ENV, "DUCKDB_PATH",
+                get(ENV, "TIINGO_DUCKDB_PATH",
+                    get(ENV, "TIINGO_DB_PATH", "tiingo_historical_data.duckdb"))))
         const DEFAULT_CSV_FILE = get(ENV, "TIINGO_TICKERS_CSV", String(cfg_get(CONFIG, ["files", "csv_file"])))
         const ZIP_FILE_PATH = get(ENV, "TIINGO_TICKERS_ZIP", String(cfg_get(CONFIG, ["files", "zip_file"])))
         const LOG_FILE = get(ENV, "TIINGO_LOG_FILE", "stock.log")


### PR DESCRIPTION
## Summary
Provider-agnostic OHLCV env-var rename, backward-compatible. Canonical `OHLCV_DUCKDB_PATH` / `OHLCV_PG_CONNECTION`; legacy `TIINGO_*` / `DUCKDB_PATH` still honored as aliases (no behavior change for existing setups). Part of a coordinated rename across TiingoJulia / quansift_scheduler / QuantScreener, plus per-repo `.env` sourcing under the scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)