### PR TITLE
fix: keep (ticker, date) PRIMARY KEY on historical_data export

### DIFF
--- a/src/db/schema.jl
+++ b/src/db/schema.jl
@@ -172,8 +172,13 @@ module Schema
         end
         query *= join(columns, ", ")
 
-        if lowercase(table_name) == "historical_data"
-            query *= ", UNIQUE (ticker, date)"
+        # Match the logical table name even when building a staging table
+        # (e.g. "historical_data_staging"), so the swapped-in table keeps the
+        # (ticker, date) key that ON CONFLICT upserts rely on. Use PRIMARY KEY
+        # so it is a valid FK target and is found by get_primary_key_columns.
+        base_name = replace(lowercase(table_name), r"_staging$" => "")
+        if base_name == "historical_data"
+            query *= ", PRIMARY KEY (ticker, date)"
         end
 
         query *= ")"


### PR DESCRIPTION
## Summary
`generate_create_table_query` only appended the `(ticker, date)` constraint when the table name exactly matched `"historical_data"`. But the PostgreSQL export builds a `historical_data_staging` table first, so the constraint was never created and was lost on every drop+rename swap. Downstream `ON CONFLICT (ticker, date)` upserts (quansift_scheduler `export_incremental_to_postgresql`) then failed with:

> there is no unique or exclusion constraint matching the ON CONFLICT specification

## Change
- Strip a trailing `_staging` before the name check so the staging table also gets the key.
- Emit `PRIMARY KEY` instead of `UNIQUE`, so the column is a valid FK target and is found by `get_primary_key_columns` in the FK-referenced upsert path.

## Verification
- Parse-checked; invoked the real `generate_create_table_query` via the loaded package:
  - `historical_data` → PRIMARY KEY ✓
  - `historical_data_staging` → PRIMARY KEY ✓ (the bug)
  - `us_tickers_filtered` → unaffected ✓

## Notes
- The daily incremental pipeline never recreates `historical_data`, so this fix only takes effect on a full re-export. The existing preprod table was remediated manually (one-time `CREATE UNIQUE INDEX CONCURRENTLY` → `ADD PRIMARY KEY USING INDEX`); prod still needs the same one-time PK add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)