### PR TITLE
docs: note canonical runtime path and dep refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ For deployment guidance, see [PRODUCTION.md](PRODUCTION.md).
 
 ## Production Deployment
 
+> **Canonical runtime = `/opt/tiingojulia`** (Docker + systemd; see below). A source checkout may also exist at `/home/shin/10kpw/TiingoJulia`; it is **not** the runtime — do not run the pipeline from there. If you build/develop from that checkout, refresh Julia deps after `git pull`: `julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()'`.
+
 The current Linux deployment path is:
 
 - `systemd timer` as the scheduler


### PR DESCRIPTION
## Summary
- Add a callout under "Production Deployment" clarifying that `/opt/tiingojulia` (Docker + systemd) is the canonical runtime, while a source checkout at `/home/shin/10kpw/TiingoJulia` is not the runtime and should not be used to run the pipeline directly.
- Note the post-pull `Pkg.instantiate()`/`Pkg.precompile()` refresh step for anyone building/developing from that checkout.

## Test plan
- [ ] README renders correctly