### PR TITLE
docs: sync staging deployment guidance to main

### DIFF
--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -56,7 +56,7 @@ The smoke test will:
 `TIINGO_DUCKDB_TMP` is separate and only controls DuckDB scratch space.
 The containerized deployment keeps scratch space and downloaded ticker temp files in `/tmp`
 but no longer overrides `OHLCV_DUCKDB_PATH`.
-On 3GB-class droplets, set `TIINGO_DUCKDB_MEMORY_LIMIT_GB=1`, `TIINGO_DUCKDB_THREADS=1`,
+On 3GB-class hosts, set `TIINGO_DUCKDB_MEMORY_LIMIT_GB=1`, `TIINGO_DUCKDB_THREADS=1`,
 `TIINGO_DUCKDB_WORKER_THREADS=1`, `TIINGO_DUCKDB_PRESERVE_INSERTION_ORDER=false`,
 and `TIINGO_DUCKDB_UPSERT_CHUNK_SIZE=500` in the app env file.
 
@@ -88,20 +88,24 @@ should point at the container-side mount location, such as `/data/tiingo_histori
 
 ### Preprod
 
+Choose your own deployment directory, DB network name, and DuckDB host directory:
+
 ```bash
-sudo mkdir -p /opt/tiingojulia
-sudo chown "$USER":"$USER" /opt/tiingojulia
-git clone https://github.com/Quansift/TiingoJulia.git /opt/tiingojulia
-cd /opt/tiingojulia
+DEPLOY_DIR=/path/to/tiingojulia
+
+sudo mkdir -p "$DEPLOY_DIR"
+sudo chown "$USER":"$USER" "$DEPLOY_DIR"
+git clone https://github.com/Quansift/TiingoJulia.git "$DEPLOY_DIR"
+cd "$DEPLOY_DIR"
 
 cp .env.staging.example .env.staging
 
-cat >/tmp/tiingojulia-pipeline <<'EOF'
+cat >/tmp/tiingojulia-pipeline <<EOF
 TIINGO_IMAGE_REPO=ghcr.io/quansift/tiingojulia
 TIINGO_IMAGE_TAG=staging
-TIINGO_APP_ENV_FILE=/opt/tiingojulia/.env.staging
-TIINGO_DOCKER_NETWORK=db-net
-TIINGO_DB_HOST_DIR=/home/<user>/tiingo/data
+TIINGO_APP_ENV_FILE=$DEPLOY_DIR/.env.staging
+TIINGO_DOCKER_NETWORK=<db-network>
+TIINGO_DB_HOST_DIR=<db-host-dir>
 TIINGO_DB_CONTAINER_DIR=/data
 EOF
 
@@ -133,20 +137,24 @@ Do not use `TIINGO_SMOKE_TICKER_LIMIT=100 docker compose ...` for this. Prefix e
 
 ### Prod
 
+Same placeholders as preprod:
+
 ```bash
-sudo mkdir -p /opt/tiingojulia
-sudo chown "$USER":"$USER" /opt/tiingojulia
-git clone https://github.com/Quansift/TiingoJulia.git /opt/tiingojulia
-cd /opt/tiingojulia
+DEPLOY_DIR=/path/to/tiingojulia
+
+sudo mkdir -p "$DEPLOY_DIR"
+sudo chown "$USER":"$USER" "$DEPLOY_DIR"
+git clone https://github.com/Quansift/TiingoJulia.git "$DEPLOY_DIR"
+cd "$DEPLOY_DIR"
 
 cp .env.example .env
 
-cat >/tmp/tiingojulia-pipeline <<'EOF'
+cat >/tmp/tiingojulia-pipeline <<EOF
 TIINGO_IMAGE_REPO=ghcr.io/quansift/tiingojulia
 TIINGO_IMAGE_TAG=latest
-TIINGO_APP_ENV_FILE=/opt/tiingojulia/.env
-TIINGO_DOCKER_NETWORK=db-net
-TIINGO_DB_HOST_DIR=/home/<user>/tiingo/data
+TIINGO_APP_ENV_FILE=$DEPLOY_DIR/.env
+TIINGO_DOCKER_NETWORK=<db-network>
+TIINGO_DB_HOST_DIR=<db-host-dir>
 TIINGO_DB_CONTAINER_DIR=/data
 EOF
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ For deployment guidance, see [PRODUCTION.md](PRODUCTION.md).
 
 ## Production Deployment
 
-> **Canonical runtime = `/opt/tiingojulia`** (Docker + systemd; see below). A source checkout may also exist at `/home/<user>/TiingoJulia`; it is **not** the runtime — do not run the pipeline from there. If you build/develop from that checkout, refresh Julia deps after `git pull`: `julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()'`.
+> **The pipeline runs via Docker + a systemd timer** from your deployment checkout (see below). If you also keep a separate source checkout for development, that checkout is **not** the runtime — do not run the pipeline from there. After `git pull` in a development checkout, refresh Julia deps: `julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()'`.
 
 The current Linux deployment path is:
 
@@ -134,15 +134,15 @@ The current Linux deployment path is:
 
 `cron` is not the recommended scheduler here. The repo ships `systemd` units and the pipeline depends on Docker plus an external DB network, which `systemd` manages more cleanly.
 `OHLCV_DUCKDB_PATH` (or legacy `TIINGO_DB_PATH`) is the intermediate DuckDB file path. `TIINGO_DUCKDB_TMP` is separate and only controls DuckDB scratch space.
-On 3GB-class droplets, set `TIINGO_DUCKDB_MEMORY_LIMIT_GB=1`, `TIINGO_DUCKDB_THREADS=1`,
+On 3GB-class hosts, set `TIINGO_DUCKDB_MEMORY_LIMIT_GB=1`, `TIINGO_DUCKDB_THREADS=1`,
 `TIINGO_DUCKDB_WORKER_THREADS=1`, and keep `TIINGO_DUCKDB_PRESERVE_INSERTION_ORDER=false`.
 
 ### Required Env Files
 
 Application env file:
 
-- Preprod: `/opt/tiingojulia/.env.staging`
-- Prod: `/opt/tiingojulia/.env`
+- Preprod: `<deploy-dir>/.env.staging`
+- Prod: `<deploy-dir>/.env`
 
 Host-side `systemd` env file:
 
@@ -166,30 +166,33 @@ The host-side `systemd` env file selects which image/env/network `docker compose
 ```dotenv
 TIINGO_IMAGE_REPO=ghcr.io/quansift/tiingojulia
 TIINGO_IMAGE_TAG=staging
-TIINGO_APP_ENV_FILE=/opt/tiingojulia/.env.staging
-TIINGO_DOCKER_NETWORK=db-net
-TIINGO_DB_HOST_DIR=/home/<user>/tiingo/data
+TIINGO_APP_ENV_FILE=<deploy-dir>/.env.staging
+TIINGO_DOCKER_NETWORK=<db-network>
+TIINGO_DB_HOST_DIR=<db-host-dir>
 TIINGO_DB_CONTAINER_DIR=/data
 ```
 
-### Preprod Droplet
+### Preprod Host
 
-Copy-paste path for preprod:
+Copy-paste path for preprod (choose your own deployment directory, DB network
+name, and DuckDB host directory):
 
 ```bash
-sudo mkdir -p /opt/tiingojulia
-sudo chown "$USER":"$USER" /opt/tiingojulia
-git clone https://github.com/Quansift/TiingoJulia.git /opt/tiingojulia
-cd /opt/tiingojulia
+DEPLOY_DIR=/path/to/tiingojulia
+
+sudo mkdir -p "$DEPLOY_DIR"
+sudo chown "$USER":"$USER" "$DEPLOY_DIR"
+git clone https://github.com/Quansift/TiingoJulia.git "$DEPLOY_DIR"
+cd "$DEPLOY_DIR"
 
 cp .env.staging.example .env.staging
 
-cat >/tmp/tiingojulia-pipeline <<'EOF'
+cat >/tmp/tiingojulia-pipeline <<EOF
 TIINGO_IMAGE_REPO=ghcr.io/quansift/tiingojulia
 TIINGO_IMAGE_TAG=staging
-TIINGO_APP_ENV_FILE=/opt/tiingojulia/.env.staging
-TIINGO_DOCKER_NETWORK=db-net
-TIINGO_DB_HOST_DIR=/home/<user>/tiingo/data
+TIINGO_APP_ENV_FILE=$DEPLOY_DIR/.env.staging
+TIINGO_DOCKER_NETWORK=<db-network>
+TIINGO_DB_HOST_DIR=<db-host-dir>
 TIINGO_DB_CONTAINER_DIR=/data
 EOF
 
@@ -208,7 +211,7 @@ systemctl list-timers tiingojulia-pipeline.timer
 journalctl -u tiingojulia-pipeline.service -f
 ```
 
-Edit `/opt/tiingojulia/.env.staging` before the first run and set at least:
+Edit `<deploy-dir>/.env.staging` before the first run and set at least:
 
 - `TIINGO_API_KEY`
 - `OHLCV_PG_CONNECTION` (or legacy `TIINGO_PG_CONNECTION`) if PostgreSQL export is enabled
@@ -225,46 +228,44 @@ docker compose -f deploy/compose/docker-compose.pipeline.yml run --rm \
 
 Do not use `TIINGO_SMOKE_TICKER_LIMIT=100 docker compose ...` for this. Prefix env vars only affect Compose interpolation and do not override values loaded into the container from `TIINGO_APP_ENV_FILE`.
 
-### Updating the checkout(s)
+### Updating the checkout
 
-On the preprod droplet TiingoJulia is checked out in **two**
-places — keep **both** current when you pull a source update, they can drift:
-
-- **`/opt/tiingojulia`** — the systemd + `docker compose` production checkout (above).
-- **`~/<user>/TiingoJulia`** — the working checkout used alongside the
-  scheduler Julia pipeline.
+If you keep more than one checkout of TiingoJulia on a host (for example a
+deployment checkout plus a development checkout), keep each current when you
+pull a source update — they can drift:
 
 ```bash
-git -C /opt/tiingojulia pull --ff-only
-git -C ~/<user>/TiingoJulia pull --ff-only
+git -C "$DEPLOY_DIR" pull --ff-only
 ```
 
 For the Docker pipeline, also refresh the image and restart the timer:
 
 ```bash
-cd /opt/tiingojulia
+cd "$DEPLOY_DIR"
 docker compose -f deploy/compose/docker-compose.pipeline.yml pull pipeline
 sudo systemctl restart tiingojulia-pipeline.timer
 ```
 
-### Prod Droplet
+### Prod Host
 
-Copy-paste path for prod:
+Copy-paste path for prod (same placeholders as preprod):
 
 ```bash
-sudo mkdir -p /opt/tiingojulia
-sudo chown "$USER":"$USER" /opt/tiingojulia
-git clone https://github.com/Quansift/TiingoJulia.git /opt/tiingojulia
-cd /opt/tiingojulia
+DEPLOY_DIR=/path/to/tiingojulia
+
+sudo mkdir -p "$DEPLOY_DIR"
+sudo chown "$USER":"$USER" "$DEPLOY_DIR"
+git clone https://github.com/Quansift/TiingoJulia.git "$DEPLOY_DIR"
+cd "$DEPLOY_DIR"
 
 cp .env.example .env
 
-cat >/tmp/tiingojulia-pipeline <<'EOF'
+cat >/tmp/tiingojulia-pipeline <<EOF
 TIINGO_IMAGE_REPO=ghcr.io/quansift/tiingojulia
 TIINGO_IMAGE_TAG=latest
-TIINGO_APP_ENV_FILE=/opt/tiingojulia/.env
-TIINGO_DOCKER_NETWORK=db-net
-TIINGO_DB_HOST_DIR=/home/<user>/tiingo/data
+TIINGO_APP_ENV_FILE=$DEPLOY_DIR/.env
+TIINGO_DOCKER_NETWORK=<db-network>
+TIINGO_DB_HOST_DIR=<db-host-dir>
 TIINGO_DB_CONTAINER_DIR=/data
 EOF
 
@@ -283,7 +284,7 @@ systemctl list-timers tiingojulia-pipeline.timer
 journalctl -u tiingojulia-pipeline.service -f
 ```
 
-Edit `/opt/tiingojulia/.env` before the first run and set:
+Edit `<deploy-dir>/.env` before the first run and set:
 
 - `TIINGO_API_KEY`
 - `OHLCV_PG_CONNECTION` (or legacy `TIINGO_PG_CONNECTION`)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,22 +1,22 @@
-# Droplet deployment (containerized pipeline)
+# Server deployment (containerized pipeline)
 
-The TiingoJulia pipeline runs as a **oneshot container** joined to the DB stack's
+The TiingoJulia pipeline runs as a **oneshot container** joined to your DB stack's
 shared Docker network, scheduled by a systemd timer. The image is built and pushed
-to GHCR by CI, so the droplet only pulls (no heavy Julia precompile on the droplet).
+to GHCR by CI, so the deployment host only pulls (no heavy Julia precompile on the host).
 
 Environment tiers (same image, config-only difference):
 
-| Domain | Role | Host | Image tag | Env file |
-|--------|------|------|-----------|----------|
-| `<preprod-domain>` | preprod | `<preprod-droplet>` | `staging` | `.env.staging` |
-| `<prod-domain>` | prod | — | `latest` (or version) | `.env` |
+| Role | Image tag | Env file |
+|------|-----------|----------|
+| preprod | `staging` | `.env.staging` |
+| prod | `latest` (or version) | `.env` |
 
-## One-time setup on a droplet
+## One-time setup on a host
 
-1. **Clone / place the repo** at `/opt/tiingojulia` (or edit `WorkingDirectory` in the
-   systemd unit to point at your checkout).
+1. **Clone / place the repo** at a deployment directory of your choice (referred to
+   below as `<deploy-dir>`), and set `WorkingDirectory` in the systemd unit to match.
 
-2. **Authenticate to GHCR** so the droplet can pull the (private) image:
+2. **Authenticate to GHCR** so the host can pull the (private) image:
 
    ```bash
    echo "$GHCR_PAT" | docker login ghcr.io -u <github-user> --password-stdin
@@ -26,7 +26,7 @@ Environment tiers (same image, config-only difference):
    then no login is needed.)
 
 3. **Create the env file** at the repo root. The PG host must be the **in-network
-   alias on port 5432** (not the host-published `127.0.0.1:5433`):
+   alias on port 5432** (not a port published on the host loopback):
 
    ```dotenv
    TIINGO_API_KEY=...
@@ -34,7 +34,8 @@ Environment tiers (same image, config-only difference):
    TIINGO_SMOKE_EXPORT_POSTGRES=true
    ```
 
-   Preprod aliases that resolve on `db-net`: `postgres`, `postgres_db`, `pdb`.
+   Use whatever alias your PostgreSQL container exposes on the shared Docker
+   network (commonly `postgres`).
 
 4. **Create the host-side systemd env file** so `docker compose` gets the right
    image tag, app env file, and external network:
@@ -48,9 +49,9 @@ Environment tiers (same image, config-only difference):
    ```dotenv
    TIINGO_IMAGE_REPO=ghcr.io/quansift/tiingojulia
    TIINGO_IMAGE_TAG=staging
-   TIINGO_APP_ENV_FILE=/opt/tiingojulia/.env.staging
-   TIINGO_DOCKER_NETWORK=db-net
-   TIINGO_DB_HOST_DIR=/home/<user>/tiingo/data
+   TIINGO_APP_ENV_FILE=<deploy-dir>/.env.staging
+   TIINGO_DOCKER_NETWORK=<db-network>
+   TIINGO_DB_HOST_DIR=<db-host-dir>
    TIINGO_DB_CONTAINER_DIR=/data
    ```
 
@@ -80,7 +81,7 @@ Environment tiers (same image, config-only difference):
 ```bash
 sudo cp deploy/systemd/tiingojulia-pipeline.service /etc/systemd/system/
 sudo cp deploy/systemd/tiingojulia-pipeline.timer   /etc/systemd/system/
-# edit WorkingDirectory in the .service if not using /opt/tiingojulia
+# edit WorkingDirectory in the .service to point at your deployment directory
 sudo systemctl daemon-reload
 sudo systemctl enable --now tiingojulia-pipeline.timer
 systemctl list-timers tiingojulia-pipeline.timer   # confirm next run
@@ -89,12 +90,12 @@ journalctl -u tiingojulia-pipeline.service -f      # follow run logs
 
 ## preprod → prod promotion
 
-Same files. On the prod droplet:
+Same files. On the prod host:
 
 - set `TIINGO_IMAGE_TAG=latest`
 - set `TIINGO_IMAGE_REPO=ghcr.io/quansift/tiingojulia`
-- set `TIINGO_APP_ENV_FILE=/opt/tiingojulia/.env`
-- keep `TIINGO_DOCKER_NETWORK=db-net` unless the prod DB stack exposes a different name
+- set `TIINGO_APP_ENV_FILE=<deploy-dir>/.env`
+- set `TIINGO_DOCKER_NETWORK` to the external Docker network name your prod DB stack exposes
 - set `TIINGO_DB_HOST_DIR` to the host directory that already contains `tiingo_historical_data.duckdb`
 - keep `TIINGO_DB_CONTAINER_DIR=/data`
 
@@ -110,7 +111,7 @@ If the prod Docker network differs, change `TIINGO_DOCKER_NETWORK` in
   selected app env file. `TIINGO_DUCKDB_TMP` is separate and only controls DuckDB
   scratch space. The compose file pins scratch space and downloaded ticker temp
   files to `/tmp` inside the container.
-- On 3GB-class droplets, set `TIINGO_DUCKDB_MEMORY_LIMIT_GB=1`,
+- On 3GB-class hosts, set `TIINGO_DUCKDB_MEMORY_LIMIT_GB=1`,
   `TIINGO_DUCKDB_THREADS=1`, `TIINGO_DUCKDB_WORKER_THREADS=1`,
   `TIINGO_DUCKDB_PRESERVE_INSERTION_ORDER=false`, and
   `TIINGO_DUCKDB_UPSERT_CHUNK_SIZE=500` in the app env file.


### PR DESCRIPTION
## What changed

- Promote the deployment-documentation update already present on `staging`.
- Limit the PR to `PRODUCTION.md`, `README.md`, and `deploy/README.md`.

## Why

`main` and `staging` diverged after the previous staging promotion was squash-merged. The equivalent sanitization commits have different SHAs, so a direct branch merge produces conflicts and a misleading large comparison. This branch applies only the one genuinely new staging commit onto current `main` without rewriting published history.

## Impact

Documentation only. No package code or runtime behavior changes.

## Validation

- `git diff --check origin/main..HEAD`
- Targeted pre-commit hooks for the three changed Markdown files
- `DOCS_DEPLOY=false julia --color=yes --project=docs docs/make.jl`
- Verified the resulting tree matches `origin/staging` exactly
