### PR TITLE
feat: resumable market-cap fundamentals backfill

### DIFF
--- a/scripts/backfill_fundamentals.jl
+++ b/scripts/backfill_fundamentals.jl
@@ -9,6 +9,7 @@ Required:
 Optional:
   OHLCV_PG_CONNECTION=postgresql://...
   FUNDAMENTALS_HISTORY_YEARS=3
+  FUNDAMENTALS_AS_OF=YYYY-MM-DD
   FUNDAMENTALS_EXPORT=true   # default false
 
 The local DuckDB is intentionally retained after partial failures. PostgreSQL
@@ -32,6 +33,16 @@ function required_backfill_path()::String
     isabspath(raw) || error("FUNDAMENTALS_DUCKDB_PATH must be absolute")
     mkpath(dirname(raw))
     return normpath(raw)
+end
+
+function configured_backfill_as_of()::Date
+    raw = strip(get(ENV, "FUNDAMENTALS_AS_OF", ""))
+    isempty(raw) && return today()
+    try
+        return Date(raw, dateformat"yyyy-mm-dd")
+    catch
+        error("FUNDAMENTALS_AS_OF must use YYYY-MM-DD")
+    end
 end
 
 function hydrate_existing_fundamentals!(conn, pg_conn_str::String)::Nothing
@@ -96,7 +107,7 @@ function main()
     history_years = parse(Int, get(ENV, "FUNDAMENTALS_HISTORY_YEARS", "3"))
     history_years > 0 || error("FUNDAMENTALS_HISTORY_YEARS must be positive")
     do_export = lowercase(get(ENV, "FUNDAMENTALS_EXPORT", "false")) == "true"
-    as_of = today()
+    as_of = configured_backfill_as_of()
     observed_at = now(UTC)
 
     conn = connect_duckdb(duckdb_path)
@@ -142,7 +153,7 @@ function main()
                 close_postgres(pg_conn)
             end
         end
-        println("FUNDAMENTALS_BACKFILL_OK requested=$(length(result.requested)) skipped=$(length(result.skipped)) observations=$(counts.observations) metrics=$(counts.metrics) exported=$do_export")
+        println("FUNDAMENTALS_BACKFILL_OK requested=$(length(result.requested)) skipped=$(length(result.skipped)) unchanged=$(length(result.unchanged)) unavailable=$(length(result.unavailable)) observations=$(counts.observations) metrics=$(counts.metrics) exported=$do_export")
     finally
         close_duckdb(conn)
     end

--- a/scripts/backfill_fundamentals.jl
+++ b/scripts/backfill_fundamentals.jl
@@ -1,0 +1,153 @@
+#!/usr/bin/env julia
+
+"""
+Resumable Tiingo Fundamentals market-cap backfill.
+
+Required:
+  FUNDAMENTALS_DUCKDB_PATH=/absolute/path/to/fundamentals-backfill.duckdb
+
+Optional:
+  OHLCV_PG_CONNECTION=postgresql://...
+  FUNDAMENTALS_HISTORY_YEARS=3
+  FUNDAMENTALS_EXPORT=true   # default false
+
+The local DuckDB is intentionally retained after partial failures. PostgreSQL
+export is limited to security_observations and fundamental_daily_metrics and is
+allowed only after every eligible request succeeds.
+"""
+
+ENV["TIINGO_LOGGER"] = get(ENV, "TIINGO_LOGGER", "console")
+
+using TiingoJulia
+using Dates
+using DataFrames
+using DBInterface
+using Logging
+
+include(joinpath(@__DIR__, "refresh_postgres_via_duckdb.jl"))
+
+function required_backfill_path()::String
+    raw = strip(get(ENV, "FUNDAMENTALS_DUCKDB_PATH", ""))
+    isempty(raw) && error("FUNDAMENTALS_DUCKDB_PATH must be set")
+    isabspath(raw) || error("FUNDAMENTALS_DUCKDB_PATH must be absolute")
+    mkpath(dirname(raw))
+    return normpath(raw)
+end
+
+function hydrate_existing_fundamentals!(conn, pg_conn_str::String)::Nothing
+    attach_postgres_readonly!(conn, pg_conn_str)
+    try
+        merge_attached_table!(
+            conn,
+            "security_observations",
+            [
+                "perma_ticker", "observed_at", "ticker", "is_active", "is_adr",
+                "daily_last_updated", "exchange", "asset_type",
+                "price_coverage_start", "price_coverage_end", "is_leveraged",
+                "join_status",
+            ],
+            ["perma_ticker", "observed_at"],
+        )
+        merge_attached_table!(
+            conn,
+            "fundamental_daily_metrics",
+            [
+                "perma_ticker", "metric_date", "market_cap", "enterprise_value",
+                "pe_ratio", "available_at", "fetched_at", "source_revision",
+            ],
+            ["perma_ticker", "metric_date"],
+        )
+    finally
+        DBInterface.execute(conn, "DETACH pg_src")
+    end
+    return nothing
+end
+
+function validate_backfill!(conn, as_of::Date)::NamedTuple
+    duplicate_metrics = Int((DBInterface.execute(conn, """
+        SELECT COUNT(*) FROM (
+            SELECT perma_ticker, metric_date
+            FROM fundamental_daily_metrics
+            GROUP BY perma_ticker, metric_date
+            HAVING COUNT(*) > 1
+        ) duplicates
+    """) |> DataFrame)[1, 1])
+    future_metrics = Int((DBInterface.execute(
+        conn,
+        "SELECT COUNT(*) FROM fundamental_daily_metrics WHERE metric_date > ?",
+        Any[as_of],
+    ) |> DataFrame)[1, 1])
+    duplicate_metrics == 0 || error("duplicate fundamental metric keys detected")
+    future_metrics == 0 || error("future-dated fundamental metrics detected")
+
+    observations = Int((
+        DBInterface.execute(conn, "SELECT count(*) FROM security_observations") |> DataFrame
+    )[1, 1])
+    metrics = Int((
+        DBInterface.execute(conn, "SELECT count(*) FROM fundamental_daily_metrics") |> DataFrame
+    )[1, 1])
+    return (; observations, metrics)
+end
+
+function main()
+    api_key = get_api_key()
+    duckdb_path = required_backfill_path()
+    pg_conn_str = get(ENV, "OHLCV_PG_CONNECTION", DEFAULT_PG_CONN_STR)
+    history_years = parse(Int, get(ENV, "FUNDAMENTALS_HISTORY_YEARS", "3"))
+    history_years > 0 || error("FUNDAMENTALS_HISTORY_YEARS must be positive")
+    do_export = lowercase(get(ENV, "FUNDAMENTALS_EXPORT", "false")) == "true"
+    as_of = today()
+    observed_at = now(UTC)
+
+    conn = connect_duckdb(duckdb_path)
+    try
+        create_tables(conn)
+        hydrate_existing_fundamentals!(conn, pg_conn_str)
+        download_tickers_duckdb(conn)
+        universe_payload = get_tickers_all(conn)
+        meta_payload = get_fundamental_meta(api_key=api_key)
+        observations = normalize_security_observations(
+            meta_payload,
+            universe_payload;
+            observed_at,
+        )
+        verify_fundamentals_entitlement!(observations, api_key; as_of)
+
+        result = sync_fundamentals!(
+            conn,
+            meta_payload,
+            universe_payload;
+            api_key,
+            as_of,
+            history_years,
+            observed_at,
+            fetched_at=observed_at,
+        )
+        if !isempty(result.failed)
+            println("FUNDAMENTALS_BACKFILL_PARTIAL failed=$(length(result.failed)) completed=$(length(result.requested)) resume_path=$duckdb_path")
+            exit(2)
+        end
+
+        counts = validate_backfill!(conn, as_of)
+        if do_export
+            pg_conn = connect_postgres(pg_conn_str)
+            try
+                export_to_postgres(
+                    conn,
+                    pg_conn,
+                    ["security_observations", "fundamental_daily_metrics"];
+                    pg_connection_string=pg_conn_str,
+                )
+            finally
+                close_postgres(pg_conn)
+            end
+        end
+        println("FUNDAMENTALS_BACKFILL_OK requested=$(length(result.requested)) skipped=$(length(result.skipped)) observations=$(counts.observations) metrics=$(counts.metrics) exported=$do_export")
+    finally
+        close_duckdb(conn)
+    end
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/scripts/refresh_postgres_via_duckdb.jl
+++ b/scripts/refresh_postgres_via_duckdb.jl
@@ -42,30 +42,54 @@ const DOW30_TICKERS = Set([
     "NKE", "NVDA", "PG", "SHW", "TRV", "UNH", "V", "VZ", "WMT",
 ])
 
-function verify_fundamentals_entitlement!(observations::DataFrame, api_key::String; as_of::Date=today())
+function verify_fundamentals_entitlement!(
+    observations::DataFrame,
+    api_key::String;
+    as_of::Date=today(),
+    daily_fetcher::Function=get_daily_fundamental,
+    max_candidates::Int=25,
+)
+    max_candidates > 0 || throw(ArgumentError("max_candidates must be positive"))
     candidates = filter(observations) do row
         row.join_status == "matched" && row.is_active &&
             !ismissing(row.asset_type) && lowercase(String(row.asset_type)) == "stock" &&
             !(String(row.ticker) in DOW30_TICKERS)
     end
     nrow(candidates) > 0 || error("no non-DOW matched stock available for entitlement probe")
-    probe = first(candidates)
-    payload = get_daily_fundamental(
-        String(probe.perma_ticker);
-        api_key,
-        start_date=as_of - Day(7),
-        end_date=as_of,
-        columns=["marketCap"],
-        return_type="original",
-    )
-    rows = isempty(payload) ? DataFrame() : DataFrame(payload)
-    has_market_cap = "marketCap" in names(rows) && any(
-        value -> !ismissing(value) && !isnothing(value),
-        rows.marketCap,
-    )
-    has_market_cap || error("Fundamentals entitlement probe returned no marketCap data")
-    @info "Fundamentals entitlement probe passed" ticker=String(probe.ticker)
-    return nothing
+    if :daily_last_updated in propertynames(candidates)
+        sort!(
+            candidates,
+            :daily_last_updated;
+            by=value -> ismissing(value) ? DateTime(1) : DateTime(value),
+            rev=true,
+        )
+    end
+
+    attempted = 0
+    for probe in eachrow(first(candidates, min(max_candidates, nrow(candidates))))
+        attempted += 1
+        try
+            payload = daily_fetcher(
+                String(probe.perma_ticker);
+                api_key,
+                start_date=as_of - Day(7),
+                end_date=as_of,
+                columns=["marketCap"],
+                return_type="original",
+            )
+            rows = isempty(payload) ? DataFrame() : DataFrame(payload)
+            has_market_cap = "marketCap" in names(rows) && any(
+                value -> !ismissing(value) && !isnothing(value),
+                rows.marketCap,
+            )
+            has_market_cap || continue
+            @info "Fundamentals entitlement probe passed" ticker=String(probe.ticker)
+            return nothing
+        catch error
+            @debug "Fundamentals entitlement candidate failed" ticker=String(probe.ticker) exception=(error, catch_backtrace())
+        end
+    end
+    error("Fundamentals entitlement probe returned no marketCap data across $attempted candidates")
 end
 
 """
@@ -324,7 +348,7 @@ function main()
             isempty(sync_result.failed) || error(
                 "Fundamentals sync incomplete for $(length(sync_result.failed)) securities; refusing export",
             )
-            @info "Fundamentals sync complete" observations=sync_result.observation_rows metrics=sync_result.metric_rows requested=length(sync_result.requested) skipped=length(sync_result.skipped) statuses=sync_result.status_counts
+            @info "Fundamentals sync complete" observations=sync_result.observation_rows metrics=sync_result.metric_rows requested=length(sync_result.requested) skipped=length(sync_result.skipped) unchanged=length(sync_result.unchanged) unavailable=length(sync_result.unavailable) statuses=sync_result.status_counts
         end
 
         # 4. Incremental update from Tiingo API

--- a/scripts/refresh_postgres_via_duckdb.jl
+++ b/scripts/refresh_postgres_via_duckdb.jl
@@ -16,13 +16,57 @@ using DBInterface
 using DuckDB
 using DataFrames
 using Logging
+using Dates
 
 # Reuse the package's postgres ATTACH mechanism (src/db/postgres.jl:525-556)
 import TiingoJulia.DB.Postgres: connection_options_map, postgres_env_vars, with_temporary_env
+import TiingoJulia.DB.Core: validate_identifier
 
 const DEFAULT_PG_CONN_STR = "postgresql://postgres@127.0.0.1:5432/tiingo?sslmode=disable"
 const DEFAULT_DUCKDB_PATH = "data/tiingo_local.duckdb"
-const TABLES_TO_EXPORT = ["historical_data", "us_tickers_filtered"]
+const TABLES_TO_HYDRATE = [
+    "historical_data",
+    "security_observations",
+    "fundamental_daily_metrics",
+]
+const TABLES_TO_EXPORT = [
+    "historical_data",
+    "us_tickers_filtered",
+    "security_observations",
+    "fundamental_daily_metrics",
+]
+
+const DOW30_TICKERS = Set([
+    "AAPL", "AMGN", "AMZN", "AXP", "BA", "CAT", "CRM", "CSCO", "CVX", "DIS",
+    "GS", "HD", "HON", "IBM", "JNJ", "JPM", "KO", "MCD", "MMM", "MRK", "MSFT",
+    "NKE", "NVDA", "PG", "SHW", "TRV", "UNH", "V", "VZ", "WMT",
+])
+
+function verify_fundamentals_entitlement!(observations::DataFrame, api_key::String; as_of::Date=today())
+    candidates = filter(observations) do row
+        row.join_status == "matched" && row.is_active &&
+            !ismissing(row.asset_type) && lowercase(String(row.asset_type)) == "stock" &&
+            !(String(row.ticker) in DOW30_TICKERS)
+    end
+    nrow(candidates) > 0 || error("no non-DOW matched stock available for entitlement probe")
+    probe = first(candidates)
+    payload = get_daily_fundamental(
+        String(probe.perma_ticker);
+        api_key,
+        start_date=as_of - Day(7),
+        end_date=as_of,
+        columns=["marketCap"],
+        return_type="original",
+    )
+    rows = isempty(payload) ? DataFrame() : DataFrame(payload)
+    has_market_cap = "marketCap" in names(rows) && any(
+        value -> !ismissing(value) && !isnothing(value),
+        rows.marketCap,
+    )
+    has_market_cap || error("Fundamentals entitlement probe returned no marketCap data")
+    @info "Fundamentals entitlement probe passed" ticker=String(probe.ticker)
+    return nothing
+end
 
 """
     attach_postgres_readonly!(conn, pg_conn_str) -> Nothing
@@ -43,41 +87,183 @@ function attach_postgres_readonly!(conn::DBInterface.Connection, pg_conn_str::St
 end
 
 """
-    hydrate_from_postgres!(conn, pg_conn_str) -> Int
+    hydrate_from_postgres!(conn, pg_conn_str) -> Dict{String,Int}
 
-Copy historical_data from PG into an empty DuckDB. This seeds the per-ticker
-latest dates that drive incremental fetching. `us_tickers_filtered` is NOT
-hydrated here: it is rebuilt fresh from Tiingo via `download_tickers_duckdb`
-so that each ticker's `endDate` reflects the current trading day (a stale
-endDate makes `update_historical` treat every ticker as up to date).
-Returns the historical_data row count. Errors on count mismatch.
+Copy persisted source tables from PostgreSQL into an empty DuckDB. The ticker
+filter is deliberately rebuilt from Tiingo so its `endDate` stays current.
+Historical data is required; fundamentals tables are optional during their
+first deployment and are exported after the refresh creates them.
 """
-function hydrate_from_postgres!(conn::DBInterface.Connection, pg_conn_str::String)::Int
+function hydrate_from_postgres!(
+    conn::DBInterface.Connection,
+    pg_conn_str::String,
+)::Dict{String,Int}
     attach_postgres_readonly!(conn, pg_conn_str)
+    counts = Dict{String,Int}()
+    try
+        counts["historical_data"] = hydrate_attached_table!(
+            conn,
+            "historical_data",
+            [
+                "ticker", "date", "close", "high", "low", "open", "volume",
+                "adjClose", "adjHigh", "adjLow", "adjOpen", "adjVolume",
+                "divCash", "splitFactor",
+            ],
+            [
+                "ticker", "date", "close", "high", "low", "open", "volume",
+                "adjclose", "adjhigh", "adjlow", "adjopen", "adjvolume",
+                "divcash", "splitfactor",
+            ];
+            required = true,
+        )
+        counts["security_observations"] = hydrate_attached_table!(
+            conn,
+            "security_observations",
+            [
+                "perma_ticker", "observed_at", "ticker", "is_active", "is_adr",
+                "daily_last_updated", "exchange", "asset_type",
+                "price_coverage_start", "price_coverage_end", "is_leveraged",
+                "join_status",
+            ],
+        )
+        counts["fundamental_daily_metrics"] = hydrate_attached_table!(
+            conn,
+            "fundamental_daily_metrics",
+            [
+                "perma_ticker", "metric_date", "market_cap", "enterprise_value",
+                "pe_ratio", "available_at", "fetched_at", "source_revision",
+            ],
+        )
+    finally
+        DBInterface.execute(conn, "DETACH pg_src;")
+    end
 
-    # Read PG count before hydration
-    pg_hist = (DBInterface.execute(conn, "SELECT count(*) FROM pg_src.historical_data") |> DataFrame)[1, 1]
-    @info "PostgreSQL source count" historical_data=pg_hist
+    @info "Hydration verified" counts
+    return counts
+end
 
-    # Explicit column mapping: DuckDB camelCase <- Postgres lowercase (same positional order)
-    @info "Hydrating historical_data ($pg_hist rows)..."
+function attached_postgres_table_exists(
+    conn::DBInterface.Connection,
+    table_name::String,
+)::Bool
+    safe_name = validate_identifier(table_name)
+    result = DBInterface.execute(
+        conn,
+        """
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_catalog = 'pg_src' AND table_name = ?
+        """,
+        (safe_name,),
+    ) |> DataFrame
+    return nrow(result) == 1
+end
+
+function hydrate_attached_table!(
+    conn::DBInterface.Connection,
+    table_name::String,
+    target_columns::Vector{String},
+    source_columns::Vector{String} = lowercase.(target_columns);
+    required::Bool = false,
+)::Int
+    safe_name = validate_identifier(table_name)
+    if !attached_postgres_table_exists(conn, safe_name)
+        required && error("Required PostgreSQL table is missing: $safe_name")
+        @info "Skipping absent PostgreSQL table during first deployment" table=safe_name
+        return 0
+    end
+
+    pg_count = Int((
+        DBInterface.execute(conn, "SELECT count(*) FROM pg_src.$safe_name") |> DataFrame
+    )[1, 1])
+    @info "Hydrating table" table=safe_name rows=pg_count
     DBInterface.execute(conn, """
-        INSERT INTO historical_data (ticker, date, close, high, low, open, volume,
-            adjClose, adjHigh, adjLow, adjOpen, adjVolume, divCash, splitFactor)
-        SELECT ticker, date, close, high, low, open, volume,
-            adjclose, adjhigh, adjlow, adjopen, adjvolume, divcash, splitfactor
-        FROM pg_src.historical_data
+        INSERT INTO $safe_name ($(join(target_columns, ", ")))
+        SELECT $(join(source_columns, ", "))
+        FROM pg_src.$safe_name
     """)
 
-    DBInterface.execute(conn, "DETACH pg_src;")
+    duck_count = Int((
+        DBInterface.execute(conn, "SELECT count(*) FROM $safe_name") |> DataFrame
+    )[1, 1])
+    duck_count == pg_count || error(
+        "Hydration mismatch: $safe_name DuckDB=$duck_count PG=$pg_count",
+    )
+    return duck_count
+end
 
-    # Verify DuckDB count matches PG
-    duck_hist = (DBInterface.execute(conn, "SELECT count(*) FROM historical_data") |> DataFrame)[1, 1]
-    @info "DuckDB post-hydration" historical_data=duck_hist
+"""
+    merge_attached_table!(conn, table_name, target_columns, key_columns; source_columns=lowercase.(target_columns)) -> Int
 
-    duck_hist != pg_hist && error("Hydration mismatch: historical_data DuckDB=$duck_hist PG=$pg_hist")
-    @info "Hydration verified"
-    return duck_hist
+Merge rows from the read-only `pg_src` attachment into an existing local table
+without replacing local rows that have the same primary key. This preserves all
+PostgreSQL keys when a resumable DuckDB already contains partial backfill data.
+"""
+function merge_attached_table!(
+    conn::DBInterface.Connection,
+    table_name::String,
+    target_columns::Vector{String},
+    key_columns::Vector{String},
+    source_columns::Vector{String} = lowercase.(target_columns),
+)::Int
+    safe_name = validate_identifier(table_name)
+    isempty(key_columns) && error("key_columns must not be empty")
+    validated_keys = validate_identifier.(key_columns)
+    if !attached_postgres_table_exists(conn, safe_name)
+        @info "Skipping absent PostgreSQL table during first deployment" table=safe_name
+        return 0
+    end
+
+    pg_count = Int((
+        DBInterface.execute(conn, "SELECT count(*) FROM pg_src.$safe_name") |> DataFrame
+    )[1, 1])
+    DBInterface.execute(conn, """
+        INSERT INTO $safe_name ($(join(target_columns, ", ")))
+        SELECT $(join(source_columns, ", "))
+        FROM pg_src.$safe_name
+        ON CONFLICT ($(join(validated_keys, ", "))) DO NOTHING
+    """)
+
+    local_count = Int((
+        DBInterface.execute(conn, "SELECT count(*) FROM $safe_name") |> DataFrame
+    )[1, 1])
+    key_match = join(
+        ["local_row.$key = source_row.$key" for key in validated_keys],
+        " AND ",
+    )
+    missing_source_keys = Int((DBInterface.execute(conn, """
+        SELECT count(*)
+        FROM pg_src.$safe_name AS source_row
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM $safe_name AS local_row
+            WHERE $key_match
+        )
+    """) |> DataFrame)[1, 1])
+    missing_source_keys == 0 || error(
+        "PostgreSQL merge lost $missing_source_keys keys from $safe_name",
+    )
+    @info "Merged PostgreSQL source into resumable DuckDB" table=safe_name pg_rows=pg_count local_rows=local_count
+    return local_count
+end
+
+function verify_hydrated_row_counts!(
+    conn::DBInterface.Connection,
+    hydrated_counts::AbstractDict{String,<:Integer},
+)::Dict{String,Int}
+    post_counts = Dict{String,Int}()
+    for table_name in TABLES_TO_HYDRATE
+        safe_name = validate_identifier(table_name)
+        post_count = Int((
+            DBInterface.execute(conn, "SELECT count(*) FROM $safe_name") |> DataFrame
+        )[1, 1])
+        hydrated_count = Int(get(hydrated_counts, safe_name, 0))
+        post_count < hydrated_count && error(
+            "ABORT: $safe_name count dropped ($post_count < $hydrated_count)",
+        )
+        post_counts[safe_name] = post_count
+    end
+    return post_counts
 end
 
 function main()
@@ -104,7 +290,7 @@ function main()
         create_tables(conn)
 
         # 3. Hydrate from PostgreSQL into DuckDB
-        hydrated_count = hydrate_from_postgres!(conn, pg_conn_str)
+        hydrated_counts = hydrate_from_postgres!(conn, pg_conn_str)
 
         # Create indexes after bulk insert for better performance
         create_indexes(conn)
@@ -114,6 +300,32 @@ function main()
         #     Without this, hydrated stale endDates make every ticker look up to date.
         @info "Refreshing ticker metadata from Tiingo..."
         download_tickers_duckdb(conn)
+
+        do_fundamentals_sync = lowercase(get(ENV, "DO_FUNDAMENTALS_SYNC", "false")) == "true"
+        if do_fundamentals_sync
+            @info "Fetching current Fundamentals identity metadata"
+            meta_payload = get_fundamental_meta(api_key=api_key)
+            universe_payload = get_tickers_all(conn)
+            observed_at = now(UTC)
+            observations = normalize_security_observations(
+                meta_payload,
+                universe_payload;
+                observed_at,
+            )
+            verify_fundamentals_entitlement!(observations, api_key)
+            sync_result = sync_fundamentals!(
+                conn,
+                meta_payload,
+                universe_payload;
+                api_key,
+                observed_at,
+                fetched_at=observed_at,
+            )
+            isempty(sync_result.failed) || error(
+                "Fundamentals sync incomplete for $(length(sync_result.failed)) securities; refusing export",
+            )
+            @info "Fundamentals sync complete" observations=sync_result.observation_rows metrics=sync_result.metric_rows requested=length(sync_result.requested) skipped=length(sync_result.skipped) statuses=sync_result.status_counts
+        end
 
         # 4. Incremental update from Tiingo API
         tickers = get_tickers_all(conn)
@@ -129,9 +341,12 @@ function main()
         @info "Incremental update done" updated=length(updated) skipped=length(missing_t)
 
         # 5. Safety gate: never export a subset
-        post_count = (DBInterface.execute(conn, "SELECT count(*) FROM historical_data") |> DataFrame)[1, 1]
-        post_count < hydrated_count && error("ABORT: count dropped ($post_count < $hydrated_count)")
-        @info "READY TO EXPORT" count=post_count added=(post_count - hydrated_count)
+        post_counts = verify_hydrated_row_counts!(conn, hydrated_counts)
+        added_counts = Dict(
+            table => post_counts[table] - hydrated_counts[table]
+            for table in TABLES_TO_HYDRATE
+        )
+        @info "READY TO EXPORT" counts=post_counts added=added_counts
 
         if !do_export
             @info "Export skipped (DO_EXPORT != \"true\"). Re-run with DO_EXPORT=true to push to PostgreSQL."
@@ -153,4 +368,6 @@ function main()
     @info "Done."
 end
 
-main()
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/src/TiingoJulia.jl
+++ b/src/TiingoJulia.jl
@@ -178,6 +178,7 @@ using .Sync
 
 # Include fundamental data module
 include("fundamental.jl")
+include("fundamental_sync.jl")
 
 # Export all public functions to maintain backward compatibility
 export get_api_key
@@ -185,11 +186,14 @@ export get_ticker_data
 export download_tickers_duckdb, download_latest_tickers, process_tickers_csv, generate_filtered_tickers
 export connect_duckdb, close_duckdb, update_us_tickers
 export upsert_stock_data, upsert_stock_data_bulk
+export upsert_security_observations, upsert_fundamental_daily_metrics
 export add_historical_data, update_historical, update_historical_parallel, update_historical_sequential, update_split_ticker
 export get_tickers_all, get_tickers_etf, get_tickers_stock
 export connect_postgres, close_postgres, export_to_postgres
 export list_tables
-export get_daily_fundamental
+export get_daily_fundamental, get_fundamental_meta
+export normalize_security_observations, normalize_fundamental_daily_metrics
+export get_fundamental_watermarks, sync_fundamentals!
 export create_or_replace_table, create_tables, create_indexes, optimize_database
 # Export types and errors
 export DatabaseConnectionError, DatabaseQueryError, DuckDBConnection, PostgreSQLConnection

--- a/src/api.jl
+++ b/src/api.jl
@@ -57,6 +57,23 @@ function get_api_key(; env_path::Union{String,Nothing}=nothing, reload_env::Bool
     return api_key
 end
 
+function _redact_api_error(error)::String
+    message = error isa AbstractString ? String(error) : sprint(showerror, error)
+    message = replace(
+        message,
+        r"(?i)((?:[\"']|%22)?authorization(?:[\"']|%22)?(?:\s|%20)*(?::|=>|=|%3d|%3a)(?:\s|%20)*(?:[\"']|%22)?(?:token|bearer)(?:\s+|%20))[^\s,;}\"'<>#]+" => s"\1[REDACTED]",
+    )
+    return replace(
+        message,
+        r"(?i)((?:[\"']|%22)?(?:token|apikey|api(?:_|-|%5f|%2d)key)(?:[\"']|%22)?(?:\s|%20)*(?::|=>|=|%3d|%3a)(?:\s|%20)*(?:[\"']|%22)?)[^&\s,;}\"'<>#]+" => s"\1[REDACTED]",
+    )
+end
+
+function _http_status_error(status, url, _body)::ErrorException
+    safe_url = _redact_api_error(url)
+    return ErrorException("HTTP $status for $safe_url; response body omitted")
+end
+
 
 """
     get_ticker_data(
@@ -95,7 +112,7 @@ end
 
 
 """
-    fetch_api_data(url::String, query::Dict, headers::Dict; max_retries::Int=3)
+    fetch_api_data(url::String, query::Dict, headers::Dict; max_retries::Int=3, allow_empty::Bool=false)
 
 Fetch data from API with retry logic and error handling.
 """
@@ -106,7 +123,8 @@ function fetch_api_data(
     max_retries::Int = Config.API.MAX_RETRIES,
     retry_delay::Int = Config.API.RETRY_DELAY,
     connect_timeout::Real = 10,
-    readtimeout::Real = 30
+    readtimeout::Real = 30,
+    allow_empty::Bool = false,
 )
     last_error = nothing
 
@@ -114,8 +132,10 @@ function fetch_api_data(
         throw(ArgumentError("max_retries must be >= 1"))
     end
 
+    safe_url = _redact_api_error(url)
+
     for attempt in 1:max_retries
-        @info "API request attempt $attempt for URL: $url"
+        @info "API request attempt $attempt for URL: $safe_url"
         response = nothing
         try
             response = HTTP.get(
@@ -126,29 +146,33 @@ function fetch_api_data(
                 readtimeout=readtimeout
             )
         catch e
-            last_error = e
-            @warn "API request attempt $attempt failed" exception=e
+            safe_error = ErrorException(_redact_api_error(e))
+            last_error = safe_error
+            @warn "API request attempt $attempt failed" error=safe_error.msg
 
             if attempt < max_retries
                 sleep(retry_delay * 2^(attempt - 1))  # Exponential backoff
                 continue
             else
-                rethrow(e)
+                throw(safe_error)
             end
         end
 
         status = response.status
         if status == 200
-            data = JSON3.read(String(response.body))
-            if isempty(data)
-                throw(ErrorException("No data returned from $url"))
+            data = try
+                JSON3.read(String(response.body))
+            catch
+                throw(ErrorException("Invalid JSON response from $safe_url"))
+            end
+            if isempty(data) && !allow_empty
+                throw(ErrorException("No data returned from $safe_url"))
             end
             return data
         end
 
         retryable = status == 429 || (status >= 500 && status <= 599)
-        body = String(response.body)
-        err = ErrorException("HTTP $status for $url: $body")
+        err = _http_status_error(status, url, response.body)
         last_error = err
 
         if retryable && attempt < max_retries

--- a/src/config.jl
+++ b/src/config.jl
@@ -142,6 +142,8 @@ module Config
             const US_TICKERS = "us_tickers"
             const US_TICKERS_FILTERED = "us_tickers_filtered"
             const HISTORICAL_DATA = "historical_data"
+            const SECURITY_OBSERVATIONS = "security_observations"
+            const FUNDAMENTAL_DAILY_METRICS = "fundamental_daily_metrics"
         end
     end
 

--- a/src/db/operations.jl
+++ b/src/db/operations.jl
@@ -126,6 +126,85 @@ module Operations
     end
 
     """
+        upsert_security_observations(conn::DuckDBConnection, data::DataFrame)::Int
+
+    Idempotently upsert observed security identity snapshots using
+    `(perma_ticker, observed_at)` as the deterministic key.
+    """
+    function upsert_security_observations(conn::DuckDBConnection, data::DataFrame)::Int
+        nrow(data) == 0 && return 0
+
+        DuckDB.register_data_frame(conn, data, UPSERT_SOURCE_VIEW)
+        try
+            DBInterface.execute(conn, """
+                INSERT INTO security_observations (
+                    perma_ticker, observed_at, ticker, is_active, is_adr,
+                    daily_last_updated, exchange, asset_type,
+                    price_coverage_start, price_coverage_end, is_leveraged,
+                    join_status
+                )
+                SELECT
+                    perma_ticker, observed_at, ticker, is_active, is_adr,
+                    daily_last_updated, exchange, asset_type,
+                    price_coverage_start, price_coverage_end, is_leveraged,
+                    join_status
+                FROM $UPSERT_SOURCE_VIEW
+                ON CONFLICT (perma_ticker, observed_at) DO UPDATE SET
+                    ticker = EXCLUDED.ticker,
+                    is_active = EXCLUDED.is_active,
+                    is_adr = EXCLUDED.is_adr,
+                    daily_last_updated = EXCLUDED.daily_last_updated,
+                    exchange = EXCLUDED.exchange,
+                    asset_type = EXCLUDED.asset_type,
+                    price_coverage_start = EXCLUDED.price_coverage_start,
+                    price_coverage_end = EXCLUDED.price_coverage_end,
+                    is_leveraged = EXCLUDED.is_leveraged,
+                    join_status = EXCLUDED.join_status
+            """)
+            return nrow(data)
+        finally
+            DuckDB.unregister_data_frame(conn, UPSERT_SOURCE_VIEW)
+        end
+    end
+
+    """
+        upsert_fundamental_daily_metrics(conn::DuckDBConnection, data::DataFrame)::Int
+
+    Idempotently upsert Daily Metrics rows using `(perma_ticker, metric_date)`
+    as the deterministic key.
+    """
+    function upsert_fundamental_daily_metrics(
+        conn::DuckDBConnection,
+        data::DataFrame,
+    )::Int
+        nrow(data) == 0 && return 0
+
+        DuckDB.register_data_frame(conn, data, UPSERT_SOURCE_VIEW)
+        try
+            DBInterface.execute(conn, """
+                INSERT INTO fundamental_daily_metrics (
+                    perma_ticker, metric_date, market_cap, enterprise_value,
+                    pe_ratio, available_at, fetched_at, source_revision
+                )
+                SELECT
+                    perma_ticker, metric_date, market_cap, enterprise_value,
+                    pe_ratio, available_at, fetched_at, source_revision
+                FROM $UPSERT_SOURCE_VIEW
+                ON CONFLICT (perma_ticker, metric_date) DO UPDATE SET
+                    market_cap = EXCLUDED.market_cap,
+                    enterprise_value = EXCLUDED.enterprise_value,
+                    pe_ratio = EXCLUDED.pe_ratio,
+                    available_at = EXCLUDED.available_at,
+                    fetched_at = EXCLUDED.fetched_at,
+                    source_revision = EXCLUDED.source_revision
+            """)
+            return nrow(data)
+        finally
+            DuckDB.unregister_data_frame(conn, UPSERT_SOURCE_VIEW)
+        end
+    end
+
+    """
         get_tickers_all(conn::DBInterface.Connection)
 
     Get all tickers from the us_tickers_filtered table.
@@ -203,6 +282,7 @@ module Operations
         """, [symbol]) |> DataFrame
     end
     export upsert_stock_data, upsert_stock_data_bulk
+    export upsert_security_observations, upsert_fundamental_daily_metrics
     export get_tickers_all, get_tickers_etf, get_tickers_stock
     export get_table_count, get_latest_dates, get_latest_date
 end

--- a/src/db/schema.jl
+++ b/src/db/schema.jl
@@ -50,6 +50,36 @@ module Schema
                 splitFactor FLOAT,
                 UNIQUE (ticker, date)
             )
+            """),
+            (Config.DB.Tables.SECURITY_OBSERVATIONS, """
+            CREATE TABLE IF NOT EXISTS security_observations (
+                perma_ticker VARCHAR NOT NULL,
+                observed_at TIMESTAMP NOT NULL,
+                ticker VARCHAR NOT NULL,
+                is_active BOOLEAN NOT NULL,
+                is_adr BOOLEAN,
+                daily_last_updated TIMESTAMP,
+                exchange VARCHAR,
+                asset_type VARCHAR,
+                price_coverage_start DATE,
+                price_coverage_end DATE,
+                is_leveraged BOOLEAN,
+                join_status VARCHAR NOT NULL,
+                PRIMARY KEY (perma_ticker, observed_at)
+            )
+            """),
+            (Config.DB.Tables.FUNDAMENTAL_DAILY_METRICS, """
+            CREATE TABLE IF NOT EXISTS fundamental_daily_metrics (
+                perma_ticker VARCHAR,
+                metric_date DATE,
+                market_cap DOUBLE,
+                enterprise_value DOUBLE,
+                pe_ratio DOUBLE,
+                available_at TIMESTAMP,
+                fetched_at TIMESTAMP NOT NULL,
+                source_revision VARCHAR,
+                PRIMARY KEY (perma_ticker, metric_date)
+            )
             """)
         ]
 
@@ -172,13 +202,17 @@ module Schema
         end
         query *= join(columns, ", ")
 
-        # Match the logical table name even when building a staging table
-        # (e.g. "historical_data_staging"), so the swapped-in table keeps the
-        # (ticker, date) key that ON CONFLICT upserts rely on. Use PRIMARY KEY
-        # so it is a valid FK target and is found by get_primary_key_columns.
+        # Match the logical table name even when building a staging table so
+        # the swapped-in table keeps the key that ON CONFLICT upserts rely on.
+        # PRIMARY KEY also makes it discoverable by get_primary_key_columns.
         base_name = replace(lowercase(table_name), r"_staging$" => "")
-        if base_name == "historical_data"
-            query *= ", PRIMARY KEY (ticker, date)"
+        primary_keys = Dict(
+            "historical_data" => ("ticker", "date"),
+            "security_observations" => ("perma_ticker", "observed_at"),
+            "fundamental_daily_metrics" => ("perma_ticker", "metric_date"),
+        )
+        if haskey(primary_keys, base_name)
+            query *= ", PRIMARY KEY ($(join(primary_keys[base_name], ", ")))"
         end
 
         query *= ")"

--- a/src/fundamental.jl
+++ b/src/fundamental.jl
@@ -9,7 +9,38 @@ using DBInterface
 using ZipFile
 
 """
-    get_daily_fundamental(ticker::String; api_key=get_api_key(), base_url="https://api.tiingo.com/tiingo/fundamentals")
+    get_fundamental_meta(; api_key=get_api_key(), columns=nothing)
+
+Fetch Tiingo's current Fundamentals metadata snapshot. The endpoint describes
+the mapping observed now; it does not provide ticker-validity dates.
+"""
+function get_fundamental_meta(;
+    api_key::String = get_api_key(),
+    base_url::String = "https://api.tiingo.com/tiingo/fundamentals",
+    return_type::String = "original",
+    columns::Union{Nothing,AbstractVector{<:AbstractString}} = nothing,
+    fetcher::Function = _fetch_fundamental_meta_data,
+)
+    headers = Dict("Content-Type" => "application/json")
+    query = Dict("token" => api_key)
+    if !isnothing(columns)
+        query["columns"] = join(columns, ",")
+    end
+    data = fetcher("$base_url/meta", query, headers)
+    if return_type == "original"
+        return data
+    elseif return_type == "dataframe"
+        return isempty(data) ? DataFrame() : DataFrame(data)
+    end
+    error("Invalid return_type. Choose 'original' or 'dataframe'.")
+end
+
+function _fetch_fundamental_meta_data(url::String, query::Dict, headers::Dict)
+    return fetch_api_data(url, query, headers; allow_empty = true)
+end
+
+"""
+    get_daily_fundamental(ticker::String; api_key=get_api_key(), base_url="https://api.tiingo.com/tiingo/fundamentals", start_date=nothing, end_date=nothing, columns=nothing)
 
 Get daily fundamental data for a given ticker from Tiingo API.
 """
@@ -18,18 +49,35 @@ function get_daily_fundamental(
     api_key::String = get_api_key(),
     base_url::String = "https://api.tiingo.com/tiingo/fundamentals",
     return_type::String = "original",
+    start_date::Union{Date,Nothing} = nothing,
+    end_date::Union{Date,Nothing} = nothing,
+    columns::Union{Nothing,AbstractVector{<:AbstractString}} = nothing,
+    fetcher::Function = _fetch_daily_fundamental_data,
 )
+    if !isnothing(start_date) && !isnothing(end_date) && start_date > end_date
+        throw(ArgumentError("start_date must be on or before end_date"))
+    end
+
     headers = Dict("Content-Type" => "application/json")
     url = "$base_url/$ticker/daily"
     query = Dict("token" => api_key)
+    if !isnothing(start_date)
+        query["startDate"] = Dates.format(start_date, "yyyy-mm-dd")
+    end
+    if !isnothing(end_date)
+        query["endDate"] = Dates.format(end_date, "yyyy-mm-dd")
+    end
+    if !isnothing(columns)
+        query["columns"] = join(columns, ",")
+    end
 
-    data = fetch_api_data(url, query, headers)
+    data = fetcher(url, query, headers)
     if return_type == "original"
         return data
     elseif return_type == "dataframe"
-        return DataFrame(data)
+        return _daily_fundamental_dataframe(data)
     elseif return_type == "timearray"
-        df = DataFrame(data)
+        df = _daily_fundamental_dataframe(data)
         return TimeArray(
             df.date,
             Matrix(df[:, Not(:date)]),
@@ -39,3 +87,32 @@ function get_daily_fundamental(
         error("Invalid return_type. Choose 'original', 'dataframe', or 'timearray'.")
     end
 end
+
+function _fetch_daily_fundamental_data(url::String, query::Dict, headers::Dict)
+    return fetch_api_data(url, query, headers; allow_empty = true)
+end
+
+function _daily_fundamental_dataframe(data)::DataFrame
+    if isempty(data)
+        return DataFrame(
+            date = Date[],
+            marketCap = Union{Missing,Float64}[],
+        )
+    end
+
+    df = DataFrame(data)
+    if hasproperty(df, :date)
+        df.date = _daily_fundamental_date.(df.date)
+    end
+    if hasproperty(df, :marketCap)
+        market_caps = Vector{Union{Missing,Float64}}(undef, nrow(df))
+        for (index, value) in enumerate(df.marketCap)
+            market_caps[index] = ismissing(value) || isnothing(value) ? missing : Float64(value)
+        end
+        df.marketCap = market_caps
+    end
+    return df
+end
+
+_daily_fundamental_date(value::Date) = value
+_daily_fundamental_date(value) = Date(first(String(value), 10))

--- a/src/fundamental_sync.jl
+++ b/src/fundamental_sync.jl
@@ -1,0 +1,416 @@
+using Dates
+using DataFrames
+using DBInterface
+
+function _canonical_security_observation_frame()::DataFrame
+    return DataFrame(
+        perma_ticker = String[],
+        observed_at = DateTime[],
+        ticker = String[],
+        is_active = Bool[],
+        is_adr = Union{Missing,Bool}[],
+        daily_last_updated = Union{Missing,DateTime}[],
+        exchange = Union{Missing,String}[],
+        asset_type = Union{Missing,String}[],
+        price_coverage_start = Union{Missing,Date}[],
+        price_coverage_end = Union{Missing,Date}[],
+        is_leveraged = Union{Missing,Bool}[],
+        join_status = String[],
+    )
+end
+
+function _canonical_daily_metrics_frame()::DataFrame
+    return DataFrame(
+        perma_ticker = String[],
+        metric_date = Date[],
+        market_cap = Union{Missing,Float64}[],
+        enterprise_value = Union{Missing,Float64}[],
+        pe_ratio = Union{Missing,Float64}[],
+        available_at = Union{Missing,DateTime}[],
+        fetched_at = DateTime[],
+        source_revision = Union{Missing,String}[],
+    )
+end
+
+function _payload_dataframe(payload)::DataFrame
+    isempty(payload) && return DataFrame()
+    return payload isa DataFrame ? copy(payload) : DataFrame(payload)
+end
+
+function _payload_value(row::DataFrameRow, aliases::Tuple)
+    for alias in aliases
+        if hasproperty(row, alias)
+            value = getproperty(row, alias)
+            return isnothing(value) ? missing : value
+        end
+    end
+    return missing
+end
+
+function _required_payload_string(row::DataFrameRow, aliases::Tuple, field_name::String)::String
+    value = _payload_value(row, aliases)
+    ismissing(value) && throw(ArgumentError("$field_name is required"))
+    normalized = strip(String(value))
+    isempty(normalized) && throw(ArgumentError("$field_name cannot be empty"))
+    return normalized
+end
+
+function _required_payload_date(row::DataFrameRow, aliases::Tuple, field_name::String)::Date
+    value = _payload_value(row, aliases)
+    ismissing(value) && throw(ArgumentError("$field_name is required"))
+    return _canonical_payload_date(value, field_name)
+end
+
+function _canonical_payload_date(value, field_name::String)::Date
+    value isa Date && return value
+    value isa DateTime && return Date(value)
+    text = String(value)
+    try
+        return Date(first(text, 10))
+    catch error
+        throw(ArgumentError("invalid $field_name: $error"))
+    end
+end
+
+function _nullable_payload_date(value, field_name::String)::Union{Missing,Date}
+    ismissing(value) && return missing
+    return _canonical_payload_date(value, field_name)
+end
+
+function _nullable_payload_datetime(value, field_name::String)::Union{Missing,DateTime}
+    ismissing(value) && return missing
+    value isa DateTime && return value
+    value isa Date && return DateTime(value)
+    text = String(value)
+    try
+        return length(text) == 10 ? DateTime(Date(text)) : DateTime(first(text, 19))
+    catch error
+        throw(ArgumentError("invalid $field_name: $error"))
+    end
+end
+
+function _nullable_payload_float(value, field_name::String)::Union{Missing,Float64}
+    ismissing(value) && return missing
+    value isa Real || throw(ArgumentError("$field_name must be numeric or missing"))
+    return Float64(value)
+end
+
+function _nullable_payload_string(value)::Union{Missing,String}
+    ismissing(value) && return missing
+    return String(value)
+end
+
+function _nullable_payload_bool(value, field_name::String)::Union{Missing,Bool}
+    ismissing(value) && return missing
+    value isa Bool && return value
+    value isa Integer && value in (0, 1) && return Bool(value)
+    if value isa AbstractString
+        normalized = lowercase(strip(value))
+        normalized == "true" && return true
+        normalized == "false" && return false
+    end
+    throw(ArgumentError("$field_name must be boolean or missing"))
+end
+
+function _required_payload_bool(row::DataFrameRow, aliases::Tuple, field_name::String)::Bool
+    value = _nullable_payload_bool(_payload_value(row, aliases), field_name)
+    ismissing(value) && throw(ArgumentError("$field_name is required"))
+    return value
+end
+
+function _count_values(values)::Dict{String,Int}
+    counts = Dict{String,Int}()
+    for value in values
+        ismissing(value) && continue
+        key = String(value)
+        counts[key] = get(counts, key, 0) + 1
+    end
+    return counts
+end
+
+"""
+    normalize_security_observations(meta_payload, universe_payload; observed_at=Dates.now())
+
+Reconcile Tiingo's current Fundamentals metadata snapshot with the local ticker
+universe. Price coverage dates are retained only as coverage facts and are never
+invented as ticker-validity dates. Every meta row is retained with a deterministic
+`join_status` so unmatched, inactive, and ambiguous identities stay auditable.
+"""
+function normalize_security_observations(
+    meta_payload,
+    universe_payload;
+    observed_at::DateTime = Dates.now(),
+)::DataFrame
+    source = _payload_dataframe(meta_payload)
+    nrow(source) == 0 && return _canonical_security_observation_frame()
+    universe = _payload_dataframe(universe_payload)
+
+    :ticker in propertynames(source) || throw(ArgumentError("meta payload is missing ticker"))
+    perma_values = if :permaTicker in propertynames(source)
+        source.permaTicker
+    elseif :perma_ticker in propertynames(source)
+        source.perma_ticker
+    else
+        throw(ArgumentError("meta payload is missing permaTicker"))
+    end
+    meta_perma_counts = _count_values(perma_values)
+    meta_ticker_counts = _count_values(source.ticker)
+
+    universe_ticker_counts = :ticker in propertynames(universe) ?
+        _count_values(universe.ticker) : Dict{String,Int}()
+    universe_by_ticker = Dict{String,DataFrameRow}()
+    if :ticker in propertynames(universe)
+        for row in eachrow(universe)
+            ticker = String(row.ticker)
+            get(universe_ticker_counts, ticker, 0) == 1 || continue
+            universe_by_ticker[ticker] = row
+        end
+    end
+
+    result = _canonical_security_observation_frame()
+    for row in eachrow(source)
+        perma_ticker = _required_payload_string(
+            row,
+            (:permaTicker, :perma_ticker),
+            "permaTicker",
+        )
+        ticker = _required_payload_string(row, (:ticker,), "ticker")
+        is_active = _required_payload_bool(row, (:isActive, :is_active), "isActive")
+        local_count = get(universe_ticker_counts, ticker, 0)
+        local_row = get(universe_by_ticker, ticker, nothing)
+        join_status = if !is_active
+            "inactive"
+        elseif get(meta_perma_counts, perma_ticker, 0) > 1
+            "duplicate_perma_ticker"
+        elseif get(meta_ticker_counts, ticker, 0) > 1
+            "duplicate_ticker"
+        elseif local_count == 0
+            "unmatched"
+        elseif local_count > 1
+            "ambiguous_universe"
+        else
+            "matched"
+        end
+
+        local_value = aliases -> isnothing(local_row) ? missing : _payload_value(local_row, aliases)
+        push!(result, (
+            perma_ticker = perma_ticker,
+            observed_at = observed_at,
+            ticker = ticker,
+            is_active = is_active,
+            is_adr = _nullable_payload_bool(
+                _payload_value(row, (:isADR, :is_adr)),
+                "isADR",
+            ),
+            daily_last_updated = _nullable_payload_datetime(
+                _payload_value(row, (:dailyLastUpdated, :daily_last_updated)),
+                "dailyLastUpdated",
+            ),
+            exchange = _nullable_payload_string(local_value((:exchange,))),
+            asset_type = _nullable_payload_string(
+                local_value((:assetType, :assettype, :asset_type)),
+            ),
+            price_coverage_start = _nullable_payload_date(
+                local_value((:startDate, :startdate, :price_coverage_start)),
+                "price coverage start",
+            ),
+            price_coverage_end = _nullable_payload_date(
+                local_value((:endDate, :enddate, :price_coverage_end)),
+                "price coverage end",
+            ),
+            is_leveraged = _nullable_payload_bool(
+                local_value((:isLeveraged, :is_leveraged)),
+                "isLeveraged",
+            ),
+            join_status = join_status,
+        ))
+    end
+    sort!(result, [:perma_ticker, :observed_at])
+    return result
+end
+
+"""
+    normalize_fundamental_daily_metrics(payload, perma_ticker; fetched_at=Dates.now())
+
+Normalize a Tiingo Daily Metrics payload. Historical `available_at` is kept
+missing unless the individual payload row explicitly supplies `availableAt`.
+"""
+function normalize_fundamental_daily_metrics(
+    payload,
+    perma_ticker::String;
+    fetched_at::DateTime = Dates.now(),
+)::DataFrame
+    normalized_perma_ticker = strip(perma_ticker)
+    isempty(normalized_perma_ticker) && throw(ArgumentError("perma_ticker cannot be empty"))
+
+    source = _payload_dataframe(payload)
+    nrow(source) == 0 && return _canonical_daily_metrics_frame()
+
+    result = _canonical_daily_metrics_frame()
+    for row in eachrow(source)
+        push!(result, (
+            perma_ticker = normalized_perma_ticker,
+            metric_date = _required_payload_date(
+                row,
+                (:date, :metricDate, :metric_date),
+                "date",
+            ),
+            market_cap = _nullable_payload_float(
+                _payload_value(row, (:marketCap, :market_cap)),
+                "marketCap",
+            ),
+            enterprise_value = _nullable_payload_float(
+                _payload_value(
+                    row,
+                    (:enterpriseVal, :enterpriseValue, :enterprise_value),
+                ),
+                "enterpriseVal",
+            ),
+            pe_ratio = _nullable_payload_float(
+                _payload_value(row, (:peRatio, :pe_ratio)),
+                "peRatio",
+            ),
+            available_at = _nullable_payload_datetime(
+                _payload_value(row, (:availableAt, :available_at)),
+                "availableAt",
+            ),
+            fetched_at = fetched_at,
+            source_revision = _nullable_payload_string(
+                _payload_value(row, (:sourceRevision, :source_revision)),
+            ),
+        ))
+    end
+    sort!(result, :metric_date)
+    return result
+end
+
+"""
+    get_fundamental_watermarks(conn) -> Dict{String,Date}
+
+Return the latest persisted metric date for each stable Tiingo identity.
+"""
+function get_fundamental_watermarks(
+    conn::DBInterface.Connection,
+)::Dict{String,Date}
+    rows = DBInterface.execute(conn, """
+        SELECT perma_ticker, MAX(metric_date) AS metric_date
+        FROM fundamental_daily_metrics
+        GROUP BY perma_ticker
+        ORDER BY perma_ticker
+    """) |> DataFrame
+    return Dict(
+        String(row.perma_ticker) => Date(row.metric_date)
+        for row in eachrow(rows)
+        if !ismissing(row.perma_ticker) && !ismissing(row.metric_date)
+    )
+end
+
+function _eligible_backfill_rows(observations::DataFrame)::DataFrame
+    eligible = filter(observations) do row
+        row.is_active && row.join_status == "matched" &&
+            !ismissing(row.asset_type) && lowercase(String(row.asset_type)) == "stock"
+    end
+    sort!(eligible, [:perma_ticker, :observed_at])
+
+    seen_perma = Set{String}()
+    seen_ticker = Set{String}()
+    for row in eachrow(eligible)
+        perma_ticker = String(row.perma_ticker)
+        ticker = String(row.ticker)
+        perma_ticker in seen_perma && throw(ArgumentError(
+            "multiple eligible rows for permaTicker $perma_ticker",
+        ))
+        ticker in seen_ticker && throw(ArgumentError(
+            "multiple eligible rows for ticker $ticker",
+        ))
+        push!(seen_perma, perma_ticker)
+        push!(seen_ticker, ticker)
+    end
+    return eligible
+end
+
+"""
+    sync_fundamentals!(conn, meta_payload, universe_payload; ...)
+
+Persist the observed current Tiingo identity mapping, then synchronize `marketCap`
+Daily Metrics for active, unambiguous stocks present in the local universe.
+Securities without a watermark request a three-year backfill; subsequent runs
+start on the day after the stable `permaTicker` watermark. Daily Metrics are
+always requested by `permaTicker`, never by the mutable ticker symbol.
+"""
+function sync_fundamentals!(
+    conn::DuckDBConnection,
+    meta_payload,
+    universe_payload;
+    api_key::String = get_api_key(),
+    as_of::Date = Date(Dates.now()),
+    history_years::Int = 3,
+    observed_at::DateTime = Dates.now(),
+    fetched_at::DateTime = Dates.now(),
+    daily_fetcher::Function = get_daily_fundamental,
+    continue_on_error::Bool = true,
+)
+    history_years > 0 || throw(ArgumentError("history_years must be positive"))
+
+    observations = normalize_security_observations(
+        meta_payload,
+        universe_payload;
+        observed_at,
+    )
+    eligible_securities = _eligible_backfill_rows(observations)
+    observation_rows = upsert_security_observations(conn, observations)
+    watermarks = get_fundamental_watermarks(conn)
+
+    requested = String[]
+    skipped = String[]
+    failed = String[]
+    metric_rows = 0
+    for security in eachrow(eligible_securities)
+        perma_ticker = String(security.perma_ticker)
+        start_date = haskey(watermarks, perma_ticker) ?
+            watermarks[perma_ticker] + Day(1) :
+            as_of - Year(history_years)
+        if start_date > as_of
+            push!(skipped, perma_ticker)
+            continue
+        end
+
+        try
+            payload = daily_fetcher(
+                perma_ticker;
+                api_key,
+                start_date,
+                end_date = as_of,
+                columns = ["marketCap"],
+                return_type = "original",
+            )
+            metrics = normalize_fundamental_daily_metrics(
+                payload,
+                perma_ticker;
+                fetched_at,
+            )
+            nrow(metrics) > 0 || error(
+                "daily Fundamentals returned no rows for $perma_ticker",
+            )
+            in_requested_range = (
+                (metrics.metric_date .>= start_date) .&
+                (metrics.metric_date .<= as_of)
+            )
+            metrics = metrics[in_requested_range, :]
+            nrow(metrics) > 0 || error(
+                "daily Fundamentals returned no rows in the requested range for $perma_ticker",
+            )
+            metric_rows += upsert_fundamental_daily_metrics(conn, metrics)
+            push!(requested, perma_ticker)
+        catch
+            continue_on_error || rethrow()
+            push!(failed, perma_ticker)
+        end
+    end
+
+    status_counts = Dict{String,Int}()
+    for status in observations.join_status
+        status_counts[status] = get(status_counts, status, 0) + 1
+    end
+    return (; observation_rows, metric_rows, requested, skipped, failed, status_counts)
+end

--- a/src/fundamental_sync.jl
+++ b/src/fundamental_sync.jl
@@ -128,6 +128,22 @@ function _count_values(values)::Dict{String,Int}
     return counts
 end
 
+function _canonical_ticker(value)::String
+    normalized = uppercase(strip(String(value)))
+    isempty(normalized) && throw(ArgumentError("ticker cannot be empty"))
+    return normalized
+end
+
+function _count_tickers(values)::Dict{String,Int}
+    counts = Dict{String,Int}()
+    for value in values
+        (ismissing(value) || isnothing(value)) && continue
+        ticker = _canonical_ticker(value)
+        counts[ticker] = get(counts, ticker, 0) + 1
+    end
+    return counts
+end
+
 """
     normalize_security_observations(meta_payload, universe_payload; observed_at=Dates.now())
 
@@ -154,14 +170,15 @@ function normalize_security_observations(
         throw(ArgumentError("meta payload is missing permaTicker"))
     end
     meta_perma_counts = _count_values(perma_values)
-    meta_ticker_counts = _count_values(source.ticker)
+    meta_ticker_counts = _count_tickers(source.ticker)
 
     universe_ticker_counts = :ticker in propertynames(universe) ?
-        _count_values(universe.ticker) : Dict{String,Int}()
+        _count_tickers(universe.ticker) : Dict{String,Int}()
     universe_by_ticker = Dict{String,DataFrameRow}()
     if :ticker in propertynames(universe)
         for row in eachrow(universe)
-            ticker = String(row.ticker)
+            (ismissing(row.ticker) || isnothing(row.ticker)) && continue
+            ticker = _canonical_ticker(row.ticker)
             get(universe_ticker_counts, ticker, 0) == 1 || continue
             universe_by_ticker[ticker] = row
         end
@@ -174,7 +191,7 @@ function normalize_security_observations(
             (:permaTicker, :perma_ticker),
             "permaTicker",
         )
-        ticker = _required_payload_string(row, (:ticker,), "ticker")
+        ticker = _canonical_ticker(_required_payload_string(row, (:ticker,), "ticker"))
         is_active = _required_payload_bool(row, (:isActive, :is_active), "isActive")
         local_count = get(universe_ticker_counts, ticker, 0)
         local_row = get(universe_by_ticker, ticker, nothing)
@@ -211,11 +228,11 @@ function normalize_security_observations(
                 local_value((:assetType, :assettype, :asset_type)),
             ),
             price_coverage_start = _nullable_payload_date(
-                local_value((:startDate, :startdate, :price_coverage_start)),
+                local_value((:startDate, :startdate, :start_date, :price_coverage_start)),
                 "price coverage start",
             ),
             price_coverage_end = _nullable_payload_date(
-                local_value((:endDate, :enddate, :price_coverage_end)),
+                local_value((:endDate, :enddate, :end_date, :price_coverage_end)),
                 "price coverage end",
             ),
             is_leveraged = _nullable_payload_bool(
@@ -363,11 +380,14 @@ function sync_fundamentals!(
 
     requested = String[]
     skipped = String[]
+    unchanged = String[]
+    unavailable = String[]
     failed = String[]
     metric_rows = 0
     for security in eachrow(eligible_securities)
         perma_ticker = String(security.perma_ticker)
-        start_date = haskey(watermarks, perma_ticker) ?
+        has_watermark = haskey(watermarks, perma_ticker)
+        start_date = has_watermark ?
             watermarks[perma_ticker] + Day(1) :
             as_of - Year(history_years)
         if start_date > as_of
@@ -389,17 +409,19 @@ function sync_fundamentals!(
                 perma_ticker;
                 fetched_at,
             )
-            nrow(metrics) > 0 || error(
-                "daily Fundamentals returned no rows for $perma_ticker",
-            )
+            if nrow(metrics) == 0
+                push!(has_watermark ? unchanged : unavailable, perma_ticker)
+                continue
+            end
             in_requested_range = (
                 (metrics.metric_date .>= start_date) .&
                 (metrics.metric_date .<= as_of)
             )
             metrics = metrics[in_requested_range, :]
-            nrow(metrics) > 0 || error(
-                "daily Fundamentals returned no rows in the requested range for $perma_ticker",
-            )
+            if nrow(metrics) == 0
+                push!(has_watermark ? unchanged : unavailable, perma_ticker)
+                continue
+            end
             metric_rows += upsert_fundamental_daily_metrics(conn, metrics)
             push!(requested, perma_ticker)
         catch
@@ -412,5 +434,14 @@ function sync_fundamentals!(
     for status in observations.join_status
         status_counts[status] = get(status_counts, status, 0) + 1
     end
-    return (; observation_rows, metric_rows, requested, skipped, failed, status_counts)
+    return (;
+        observation_rows,
+        metric_rows,
+        requested,
+        skipped,
+        unchanged,
+        unavailable,
+        failed,
+        status_counts,
+    )
 end

--- a/test/test_api.jl
+++ b/test/test_api.jl
@@ -57,7 +57,7 @@ using TiingoJulia.API
     @testset "fetch_api_data" begin
         if get(ENV, "TIINGO_TEST_LIVE_API", "false") == "true"
             # Test the error handling path using a known-bad URL
-            @test_throws HTTP.Exceptions.ConnectError fetch_api_data(
+            @test_throws ErrorException fetch_api_data(
                 "http://invalid-url-for-testing.com",
                 Dict("param" => "value"),
                 Dict("Authorization" => "Token invalid-key")
@@ -65,6 +65,63 @@ using TiingoJulia.API
         else
             @test_skip "Skipping live network test (set TIINGO_TEST_LIVE_API=true to enable)"
         end
+    end
+
+    @testset "API errors redact credentials" begin
+        cases = [
+            (
+                "GET /daily?token=secret-token&columns=marketCap",
+                ["secret-token"],
+            ),
+            (
+                "GET /daily?apikey=secret.apikey&api_key=secret_key&api-key=secret-key",
+                ["secret.apikey", "secret_key", "secret-key"],
+            ),
+            (
+                "GET /daily?api%5Fkey%3Dsecret%2Fencoded%2Bvalue",
+                ["secret%2Fencoded%2Bvalue"],
+            ),
+            (
+                "Authorization: Token secret-token",
+                ["secret-token"],
+            ),
+            (
+                "\"Authorization\" => \"Bearer secret.bearer-token\"",
+                ["secret.bearer-token"],
+            ),
+            (
+                "%22Authorization%22%3A%20%22Token%20encoded-header-secret%22",
+                ["encoded-header-secret"],
+            ),
+            (
+                "HTTP 401: {\"api_key\":\"body-secret\",\"token\":\"other-secret\"}",
+                ["body-secret", "other-secret"],
+            ),
+            (
+                "Dict(\"api_key\" => \"dict-secret\")",
+                ["dict-secret"],
+            ),
+        ]
+
+        for (input, secrets) in cases
+            message = API._redact_api_error(ErrorException(input))
+            @test all(secret -> !occursin(secret, message), secrets)
+            @test occursin("[REDACTED]", message)
+        end
+
+        message = API._redact_api_error("GET /daily?token=secret-token")
+        @test !occursin("secret-token", message)
+        @test occursin("token=[REDACTED]", message)
+
+        status_error = API._http_status_error(
+            401,
+            "https://example.test/daily?token=url-secret",
+            "arbitrary unlabelled body secret",
+        )
+        status_message = sprint(showerror, status_error)
+        @test !occursin("url-secret", status_message)
+        @test !occursin("arbitrary unlabelled body secret", status_message)
+        @test occursin("response body omitted", status_message)
     end
 
     @testset "download_tickers_duckdb" begin

--- a/test/test_db.jl
+++ b/test/test_db.jl
@@ -86,10 +86,16 @@ end
         tables_query = """
             SELECT table_name
             FROM information_schema.tables
-            WHERE table_name IN ('us_tickers', 'us_tickers_filtered', 'historical_data')
+            WHERE table_name IN (
+                'us_tickers',
+                'us_tickers_filtered',
+                'historical_data',
+                'security_observations',
+                'fundamental_daily_metrics'
+            )
         """
         tables = DBInterface.execute(conn, tables_query) |> DataFrame
-        @test nrow(tables) == 3
+        @test nrow(tables) == 5
 
         # Test table schemas
         historical_schema =

--- a/test/test_fundamental.jl
+++ b/test/test_fundamental.jl
@@ -1,0 +1,134 @@
+using Test
+using Dates
+using DataFrames
+using TimeSeries
+using TiingoJulia
+
+@testset "Fundamental meta request contract" begin
+    captured = Ref{Any}(nothing)
+    payload = [(permaTicker="perm-aapl", ticker="AAPL", isActive=true)]
+    fetcher = function (url, query, headers)
+        captured[] = (; url, query, headers)
+        return payload
+    end
+
+    result = get_fundamental_meta(;
+        api_key="offline-token",
+        base_url="https://example.test/tiingo/fundamentals",
+        columns=["permaTicker", "ticker", "isActive"],
+        return_type="dataframe",
+        fetcher=fetcher,
+    )
+
+    @test captured[].url == "https://example.test/tiingo/fundamentals/meta"
+    @test captured[].query == Dict(
+        "token" => "offline-token",
+        "columns" => "permaTicker,ticker,isActive",
+    )
+    @test captured[].headers == Dict("Content-Type" => "application/json")
+    @test result.permaTicker == ["perm-aapl"]
+end
+
+@testset "Daily fundamental request contract" begin
+    captured = Ref{Any}(nothing)
+    payload = [
+        (date = "2026-07-18", marketCap = 3.0e12),
+        (date = "2026-07-19T00:00:00.000Z", marketCap = nothing),
+    ]
+    fetcher = function (url, query, headers)
+        captured[] = (; url, query, headers)
+        return payload
+    end
+
+    result = get_daily_fundamental(
+        "AAPL";
+        api_key = "offline-token",
+        base_url = "https://example.test/tiingo/fundamentals",
+        start_date = Date(2026, 7, 1),
+        end_date = Date(2026, 7, 19),
+        columns = ["marketCap"],
+        return_type = "dataframe",
+        fetcher,
+    )
+
+    @test captured[].url == "https://example.test/tiingo/fundamentals/AAPL/daily"
+    @test captured[].query == Dict(
+        "token" => "offline-token",
+        "startDate" => "2026-07-01",
+        "endDate" => "2026-07-19",
+        "columns" => "marketCap",
+    )
+    @test captured[].headers == Dict("Content-Type" => "application/json")
+    @test result isa DataFrame
+    @test result.date == [Date(2026, 7, 18), Date(2026, 7, 19)]
+    @test eltype(result.date) == Date
+    @test isequal(result.marketCap, Union{Missing,Float64}[3.0e12, missing])
+    @test eltype(result.marketCap) == Union{Missing,Float64}
+end
+
+@testset "Daily fundamental rejects reversed dates before fetching" begin
+    fetch_count = Ref(0)
+    fetcher = function (url, query, headers)
+        fetch_count[] += 1
+        return Any[]
+    end
+
+    @test_throws ArgumentError get_daily_fundamental(
+        "AAPL";
+        api_key = "offline-token",
+        start_date = Date(2026, 7, 20),
+        end_date = Date(2026, 7, 19),
+        fetcher,
+    )
+    @test fetch_count[] == 0
+end
+
+@testset "Daily fundamental handles empty payload" begin
+    result = get_daily_fundamental(
+        "AAPL";
+        api_key = "offline-token",
+        columns = ["marketCap"],
+        return_type = "dataframe",
+        fetcher = (url, query, headers) -> Any[],
+    )
+
+    @test isempty(result)
+    @test names(result) == ["date", "marketCap"]
+    @test eltype(result.date) == Date
+    @test eltype(result.marketCap) == Union{Missing,Float64}
+end
+
+@testset "Daily fundamental return type compatibility" begin
+    payload = [(date = "2026-07-18", marketCap = 3.0e12)]
+    captured_query = Ref{Any}(nothing)
+    fetcher = function (url, query, headers)
+        captured_query[] = copy(query)
+        return payload
+    end
+
+    original = get_daily_fundamental(
+        "AAPL";
+        api_key = "offline-token",
+        fetcher,
+    )
+    @test captured_query[] == Dict("token" => "offline-token")
+    dataframe = get_daily_fundamental(
+        "AAPL";
+        api_key = "offline-token",
+        return_type = "dataframe",
+        fetcher,
+    )
+    timearray = get_daily_fundamental(
+        "AAPL";
+        api_key = "offline-token",
+        return_type = "timearray",
+        fetcher,
+    )
+
+    @test original === payload
+    @test dataframe isa DataFrame
+    @test dataframe.date == [Date(2026, 7, 18)]
+    @test timearray isa TimeArray
+    @test timestamp(timearray) == [Date(2026, 7, 18)]
+    @test values(timearray)[1, 1] == 3.0e12
+end

--- a/test/test_fundamental_persistence.jl
+++ b/test/test_fundamental_persistence.jl
@@ -1,0 +1,161 @@
+using Test
+using Dates
+using DataFrames
+using DuckDB
+using DBInterface
+using TiingoJulia
+using TiingoJulia.DB.Schema: generate_create_table_query
+
+@testset "Fundamental persistence schema and keys" begin
+    conn = connect_duckdb(":memory:")
+    try
+        tables = DBInterface.execute(conn, """
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_name IN ('security_observations', 'fundamental_daily_metrics')
+            ORDER BY table_name
+        """) |> DataFrame
+        @test tables.table_name == ["fundamental_daily_metrics", "security_observations"]
+
+        security_schema = DBInterface.execute(conn, "DESCRIBE security_observations") |> DataFrame
+        metrics_schema = DBInterface.execute(conn, "DESCRIBE fundamental_daily_metrics") |> DataFrame
+        @test security_schema.column_name == [
+            "perma_ticker",
+            "observed_at",
+            "ticker",
+            "is_active",
+            "is_adr",
+            "daily_last_updated",
+            "exchange",
+            "asset_type",
+            "price_coverage_start",
+            "price_coverage_end",
+            "is_leveraged",
+            "join_status",
+        ]
+        @test metrics_schema.column_name == [
+            "perma_ticker",
+            "metric_date",
+            "market_cap",
+            "enterprise_value",
+            "pe_ratio",
+            "available_at",
+            "fetched_at",
+            "source_revision",
+        ]
+        @test security_schema[coalesce.(security_schema.key .== "PRI", false), :column_name] == [
+            "perma_ticker",
+            "observed_at",
+        ]
+        @test metrics_schema[coalesce.(metrics_schema.key .== "PRI", false), :column_name] == [
+            "perma_ticker",
+            "metric_date",
+        ]
+
+        historical_schema = DBInterface.execute(conn, "DESCRIBE historical_data") |> DataFrame
+        historical_query = generate_create_table_query("historical_data_staging", historical_schema)
+        security_query = generate_create_table_query("security_observations_staging", security_schema)
+        metrics_query = generate_create_table_query("fundamental_daily_metrics_staging", metrics_schema)
+        @test occursin("PRIMARY KEY (ticker, date)", historical_query)
+        @test occursin("PRIMARY KEY (perma_ticker, observed_at)", security_query)
+        @test occursin("PRIMARY KEY (perma_ticker, metric_date)", metrics_query)
+    finally
+        close_duckdb(conn)
+    end
+end
+
+@testset "Security observation upsert is idempotent" begin
+    conn = connect_duckdb(":memory:")
+    try
+        original = DataFrame(
+            perma_ticker = ["perm-aapl"],
+            observed_at = [DateTime(2026, 7, 19, 12)],
+            ticker = ["AAPL"],
+            is_active = [true],
+            is_adr = Union{Missing,Bool}[false],
+            daily_last_updated = Union{Missing,DateTime}[DateTime(2026, 7, 19, 10)],
+            exchange = ["NASDAQ"],
+            asset_type = ["Stock"],
+            price_coverage_start = Union{Missing,Date}[Date(1980, 12, 12)],
+            price_coverage_end = Union{Missing,Date}[Date(2026, 7, 19)],
+            is_leveraged = Union{Missing,Bool}[missing],
+            join_status = ["matched"],
+        )
+        @test upsert_security_observations(conn, original) == 1
+
+        revised = copy(original)
+        revised.exchange .= "NASDAQ GLOBAL SELECT"
+        revised.is_leveraged .= false
+        revised.daily_last_updated .= DateTime(2026, 7, 19, 11)
+        @test upsert_security_observations(conn, revised) == 1
+
+        stored = DBInterface.execute(conn, "SELECT * FROM security_observations") |> DataFrame
+        @test nrow(stored) == 1
+        @test stored.exchange == ["NASDAQ GLOBAL SELECT"]
+        @test stored.is_leveraged == [false]
+        @test stored.daily_last_updated == [DateTime(2026, 7, 19, 11)]
+    finally
+        close_duckdb(conn)
+    end
+end
+
+@testset "Daily metrics upsert supports nullable and as-of-compatible facts" begin
+    conn = connect_duckdb(":memory:")
+    try
+        rows = DataFrame(
+            perma_ticker = fill("perm-aapl", 4),
+            metric_date = [
+                Date(2024, 1, 31),
+                Date(2024, 2, 29),
+                Date(2024, 3, 31),
+                Date(2025, 1, 1),
+            ],
+            market_cap = Union{Missing,Float64}[10.0e9, 11.0e9, missing, 12.0e9],
+            enterprise_value = Union{Missing,Float64}[9.0e9, missing, missing, 11.0e9],
+            pe_ratio = Union{Missing,Float64}[20.0, 21.0, missing, 22.0],
+            available_at = Union{Missing,DateTime}[
+                DateTime(2024, 2, 1, 12),
+                DateTime(2025, 1, 5, 12),
+                missing,
+                DateTime(2025, 1, 2, 12),
+            ],
+            fetched_at = fill(DateTime(2026, 7, 19, 12), 4),
+            source_revision = Union{Missing,String}["rev-1", "rev-1", missing, "rev-1"],
+        )
+        @test upsert_fundamental_daily_metrics(conn, rows) == 4
+
+        revised = copy(rows)
+        revised.market_cap[1] = 10.5e9
+        revised.pe_ratio[1] = 20.5
+        revised.source_revision[1] = "rev-2"
+        @test upsert_fundamental_daily_metrics(conn, revised) == 4
+
+        stored = DBInterface.execute(
+            conn,
+            "SELECT * FROM fundamental_daily_metrics ORDER BY metric_date",
+        ) |> DataFrame
+        @test nrow(stored) == 4
+        @test stored.market_cap[1] == 10.5e9
+        @test stored.pe_ratio[1] == 20.5
+        @test stored.source_revision[1] == "rev-2"
+        @test ismissing(stored.market_cap[3])
+        @test ismissing(stored.enterprise_value[3])
+        @test ismissing(stored.pe_ratio[3])
+
+        as_of = Date(2024, 12, 31)
+        observable = DBInterface.execute(
+            conn,
+            """
+            SELECT metric_date
+            FROM fundamental_daily_metrics
+            WHERE metric_date <= ?
+              AND (available_at IS NULL OR available_at <= ?)
+            ORDER BY metric_date
+            """,
+            (as_of, DateTime(2024, 12, 31, 23, 59, 59)),
+        ) |> DataFrame
+        @test observable.metric_date == [Date(2024, 1, 31), Date(2024, 3, 31)]
+    finally
+        close_duckdb(conn)
+    end
+end

--- a/test/test_fundamental_sync.jl
+++ b/test/test_fundamental_sync.jl
@@ -1,0 +1,348 @@
+using Test
+using Dates
+using DataFrames
+using DuckDB
+using DBInterface
+using TiingoJulia
+
+@testset "Official meta reconciles as observations without invented validity" begin
+    observed_at = DateTime(2026, 7, 19, 12)
+    meta_payload = [
+        (
+            permaTicker = "perm-aapl",
+            ticker = "AAPL",
+            isActive = true,
+            isADR = false,
+            dailyLastUpdated = "2026-07-18T23:00:00Z",
+        ),
+        (permaTicker = "perm-dead", ticker = "DEAD", isActive = false, isADR = false, dailyLastUpdated = nothing),
+        (permaTicker = "perm-missing", ticker = "MISS", isActive = true, isADR = false, dailyLastUpdated = nothing),
+    ]
+    universe_payload = [
+        (
+            ticker = "AAPL",
+            exchange = "NASDAQ",
+            assetType = "Stock",
+            startDate = "1980-12-12",
+            endDate = "2026-07-19",
+        ),
+    ]
+
+    normalized = normalize_security_observations(
+        meta_payload,
+        universe_payload;
+        observed_at,
+    )
+    @test names(normalized) == [
+        "perma_ticker",
+        "observed_at",
+        "ticker",
+        "is_active",
+        "is_adr",
+        "daily_last_updated",
+        "exchange",
+        "asset_type",
+        "price_coverage_start",
+        "price_coverage_end",
+        "is_leveraged",
+        "join_status",
+    ]
+    aapl = only(eachrow(filter(row -> row.ticker == "AAPL", normalized)))
+    @test aapl.observed_at == observed_at
+    @test aapl.join_status == "matched"
+    @test aapl.exchange == "NASDAQ"
+    @test aapl.asset_type == "Stock"
+    @test aapl.price_coverage_start == Date(1980, 12, 12)
+    @test aapl.price_coverage_end == Date(2026, 7, 19)
+    @test ismissing(aapl.is_leveraged)
+    @test only(eachrow(filter(row -> row.ticker == "DEAD", normalized))).join_status == "inactive"
+    @test only(eachrow(filter(row -> row.ticker == "MISS", normalized))).join_status == "unmatched"
+    @test !(:valid_from in propertynames(normalized))
+    @test !(:valid_to in propertynames(normalized))
+end
+
+@testset "Duplicate identities are quarantined" begin
+    observed_at = DateTime(2026, 7, 19, 12)
+    universe = [
+        (ticker="DUP", exchange="NYSE", assetType="Stock", startDate="2020-01-01", endDate="2026-07-19"),
+    ]
+    duplicate_perma = [
+        (permaTicker="perm-dup", ticker="DUP", isActive=true, isADR=false, dailyLastUpdated=nothing),
+        (permaTicker="perm-dup", ticker="DUP.NEW", isActive=true, isADR=false, dailyLastUpdated=nothing),
+    ]
+    normalized = normalize_security_observations(duplicate_perma, universe; observed_at)
+    @test all(normalized.join_status .== "duplicate_perma_ticker")
+
+    duplicate_ticker = [
+        (permaTicker="perm-1", ticker="DUP", isActive=true, isADR=false, dailyLastUpdated=nothing),
+        (permaTicker="perm-2", ticker="DUP", isActive=true, isADR=false, dailyLastUpdated=nothing),
+    ]
+    normalized = normalize_security_observations(duplicate_ticker, universe; observed_at)
+    @test all(normalized.join_status .== "duplicate_ticker")
+end
+
+@testset "Daily API payload normalizes nullable metrics and provenance" begin
+    fetched_at = DateTime(2026, 7, 19, 12)
+    payload = [
+        (
+            date = "2024-01-31T00:00:00.000Z",
+            marketCap = 3.0e12,
+            enterpriseVal = nothing,
+            peRatio = 25.0,
+            availableAt = nothing,
+            dailyLastUpdated = "2026-07-19T12:00:00Z",
+            sourceRevision = nothing,
+        ),
+        (
+            date = "2024-02-01",
+            marketCap = nothing,
+            enterpriseVal = 3.1e12,
+            peRatio = nothing,
+            availableAt = "2024-02-02T14:30:00Z",
+            dailyLastUpdated = nothing,
+            sourceRevision = "revision-2",
+        ),
+    ]
+
+    normalized = normalize_fundamental_daily_metrics(
+        payload,
+        "perm-aapl";
+        fetched_at,
+    )
+    @test names(normalized) == [
+        "perma_ticker",
+        "metric_date",
+        "market_cap",
+        "enterprise_value",
+        "pe_ratio",
+        "available_at",
+        "fetched_at",
+        "source_revision",
+    ]
+    @test normalized.perma_ticker == ["perm-aapl", "perm-aapl"]
+    @test normalized.metric_date == [Date(2024, 1, 31), Date(2024, 2, 1)]
+    @test normalized.market_cap[1] == 3.0e12
+    @test ismissing(normalized.market_cap[2])
+    @test ismissing(normalized.enterprise_value[1])
+    @test normalized.enterprise_value[2] == 3.1e12
+    @test normalized.pe_ratio[1] == 25.0
+    @test ismissing(normalized.pe_ratio[2])
+    @test ismissing(normalized.available_at[1])
+    @test normalized.available_at[2] == DateTime(2024, 2, 2, 14, 30)
+    @test normalized.fetched_at == fill(fetched_at, 2)
+    @test ismissing(normalized.source_revision[1])
+    @test normalized.source_revision[2] == "revision-2"
+end
+
+@testset "Fundamentals sync backfills then advances by watermark" begin
+    conn = connect_duckdb(":memory:")
+    try
+        as_of = Date(2026, 7, 19)
+        fetched_at = DateTime(2026, 7, 19, 12)
+        response_date = Ref(as_of)
+        calls = NamedTuple[]
+        daily_fetcher = function (
+            ticker;
+            api_key,
+            start_date,
+            end_date,
+            columns,
+            return_type,
+        )
+            push!(calls, (; ticker, api_key, start_date, end_date, columns, return_type))
+            return [
+                (date = string(response_date[]), marketCap = 3.0e12),
+                (date = string(end_date + Day(1)), marketCap = 4.0e12),
+            ]
+        end
+        meta_payload = [(
+            permaTicker = "perm-aapl",
+            ticker = "AAPL",
+            isActive = true,
+            isADR = false,
+            dailyLastUpdated = string(fetched_at),
+        )]
+        universe_payload = [(
+            ticker = "AAPL",
+            exchange = "NASDAQ",
+            assetType = "Stock",
+            startDate = "1980-12-12",
+            endDate = string(as_of),
+        )]
+
+        initial = sync_fundamentals!(
+            conn,
+            meta_payload,
+            universe_payload;
+            api_key = "offline-token",
+            as_of,
+            history_years = 3,
+            observed_at = fetched_at,
+            fetched_at,
+            daily_fetcher,
+        )
+        @test initial.observation_rows == 1
+        @test initial.metric_rows == 1
+        @test initial.requested == ["perm-aapl"]
+        @test isempty(initial.skipped)
+        @test isempty(initial.failed)
+        @test length(calls) == 1
+        @test calls[1].ticker == "perm-aapl"
+        @test calls[1].start_date == Date(2023, 7, 19)
+        @test calls[1].end_date == as_of
+        @test calls[1].columns == ["marketCap"]
+        @test calls[1].return_type == "original"
+
+        stored_security = DBInterface.execute(conn, "SELECT * FROM security_observations") |> DataFrame
+        stored_metrics = DBInterface.execute(
+            conn,
+            "SELECT * FROM fundamental_daily_metrics",
+        ) |> DataFrame
+        @test stored_security.perma_ticker == ["perm-aapl"]
+        @test stored_metrics.perma_ticker == ["perm-aapl"]
+        @test stored_metrics.metric_date == [as_of]
+        @test ismissing(stored_metrics.available_at[1])
+        @test stored_metrics.fetched_at == [fetched_at]
+
+        repeated = sync_fundamentals!(
+            conn,
+            meta_payload,
+            universe_payload;
+            api_key = "offline-token",
+            as_of,
+            history_years = 3,
+            observed_at = fetched_at,
+            fetched_at,
+            daily_fetcher,
+        )
+        @test repeated.metric_rows == 0
+        @test repeated.skipped == ["perm-aapl"]
+        @test length(calls) == 1
+        @test (
+            DBInterface.execute(conn, "SELECT count(*) FROM fundamental_daily_metrics") |>
+            DataFrame
+        )[1, 1] == 1
+
+        next_as_of = as_of + Day(1)
+        response_date[] = next_as_of
+        incremental = sync_fundamentals!(
+            conn,
+            meta_payload,
+            universe_payload;
+            api_key = "offline-token",
+            as_of = next_as_of,
+            history_years = 3,
+            observed_at = fetched_at + Day(1),
+            fetched_at = fetched_at + Day(1),
+            daily_fetcher,
+        )
+        @test incremental.metric_rows == 1
+        @test length(calls) == 2
+        @test calls[2].start_date == next_as_of
+        @test calls[2].end_date == next_as_of
+        @test (
+            DBInterface.execute(conn, "SELECT count(*) FROM fundamental_daily_metrics") |>
+            DataFrame
+        )[1, 1] == 2
+        @test get_fundamental_watermarks(conn) == Dict("perm-aapl" => next_as_of)
+
+        renamed_as_of = next_as_of + Day(1)
+        response_date[] = renamed_as_of
+        renamed_payload = [
+            (
+                permaTicker = "perm-aapl",
+                ticker = "AAPL.NEW",
+                isActive = true,
+                isADR = false,
+                dailyLastUpdated = string(fetched_at + Day(2)),
+            ),
+        ]
+        renamed_universe = [(
+            ticker = "AAPL.NEW",
+            exchange = "NASDAQ",
+            assetType = "Stock",
+            startDate = "1980-12-12",
+            endDate = string(renamed_as_of),
+        )]
+        renamed = sync_fundamentals!(
+            conn,
+            renamed_payload,
+            renamed_universe;
+            api_key = "offline-token",
+            as_of = renamed_as_of,
+            history_years = 3,
+            observed_at = fetched_at + Day(2),
+            fetched_at = fetched_at + Day(2),
+            daily_fetcher,
+        )
+        @test renamed.metric_rows == 1
+        @test calls[end].ticker == "perm-aapl"
+        @test calls[end].start_date == renamed_as_of
+        @test calls[end].end_date == renamed_as_of
+        @test (
+            DBInterface.execute(conn, "SELECT count(*) FROM security_observations") |>
+            DataFrame
+        )[1, 1] == 3
+        observations = DBInterface.execute(
+            conn,
+            "SELECT ticker FROM security_observations ORDER BY observed_at",
+        ) |> DataFrame
+        @test observations.ticker == ["AAPL", "AAPL", "AAPL.NEW"]
+        @test get_fundamental_watermarks(conn) == Dict("perm-aapl" => renamed_as_of)
+    finally
+        close_duckdb(conn)
+    end
+end
+
+@testset "Empty daily Fundamentals payload fails the security" begin
+    conn = connect_duckdb(":memory:")
+    try
+        as_of = Date(2026, 7, 19)
+        observed_at = DateTime(2026, 7, 19, 12)
+        meta_payload = [(
+            permaTicker = "perm-empty",
+            ticker = "EMPTY",
+            isActive = true,
+            isADR = false,
+            dailyLastUpdated = string(observed_at),
+        )]
+        universe_payload = [(
+            ticker = "EMPTY",
+            exchange = "NASDAQ",
+            assetType = "Stock",
+            startDate = "2020-01-01",
+            endDate = string(as_of),
+        )]
+        empty_fetcher = function (
+            ticker;
+            api_key,
+            start_date,
+            end_date,
+            columns,
+            return_type,
+        )
+            return NamedTuple[]
+        end
+
+        result = sync_fundamentals!(
+            conn,
+            meta_payload,
+            universe_payload;
+            api_key = "offline-token",
+            as_of,
+            observed_at,
+            fetched_at = observed_at,
+            daily_fetcher = empty_fetcher,
+        )
+
+        @test isempty(result.requested)
+        @test result.failed == ["perm-empty"]
+        @test result.metric_rows == 0
+        @test (
+            DBInterface.execute(conn, "SELECT count(*) FROM fundamental_daily_metrics") |>
+            DataFrame
+        )[1, 1] == 0
+    finally
+        close_duckdb(conn)
+    end
+end

--- a/test/test_fundamental_sync.jl
+++ b/test/test_fundamental_sync.jl
@@ -61,6 +61,36 @@ using TiingoJulia
     @test !(:valid_to in propertynames(normalized))
 end
 
+@testset "Fundamentals metadata tickers reconcile case-insensitively" begin
+    observed_at = DateTime(2026, 7, 22, 12)
+    meta_payload = [(
+        permaTicker = "perm-googl",
+        ticker = "googl",
+        isActive = true,
+        isADR = false,
+        dailyLastUpdated = "2026-07-22T01:52:38Z",
+    )]
+    universe_payload = [(
+        ticker = "GOOGL",
+        exchange = "NASDAQ",
+        asset_type = "Stock",
+        start_date = "2004-08-19",
+        end_date = "2026-07-22",
+    )]
+
+    normalized = normalize_security_observations(
+        meta_payload,
+        universe_payload;
+        observed_at,
+    )
+
+    @test only(normalized.join_status) == "matched"
+    @test only(normalized.ticker) == "GOOGL"
+    @test only(normalized.asset_type) == "Stock"
+    @test only(normalized.price_coverage_start) == Date(2004, 8, 19)
+    @test only(normalized.price_coverage_end) == Date(2026, 7, 22)
+end
+
 @testset "Duplicate identities are quarantined" begin
     observed_at = DateTime(2026, 7, 19, 12)
     universe = [
@@ -294,7 +324,7 @@ end
     end
 end
 
-@testset "Empty daily Fundamentals payload fails the security" begin
+@testset "Empty daily Fundamentals payload is unavailable, not failed" begin
     conn = connect_duckdb(":memory:")
     try
         as_of = Date(2026, 7, 19)
@@ -336,12 +366,109 @@ end
         )
 
         @test isempty(result.requested)
-        @test result.failed == ["perm-empty"]
+        @test result.unavailable == ["perm-empty"]
+        @test isempty(result.failed)
         @test result.metric_rows == 0
         @test (
             DBInterface.execute(conn, "SELECT count(*) FROM fundamental_daily_metrics") |>
             DataFrame
         )[1, 1] == 0
+    finally
+        close_duckdb(conn)
+    end
+end
+
+@testset "No newer Daily Metrics row is unchanged after a watermark" begin
+    conn = connect_duckdb(":memory:")
+    try
+        as_of = Date(2026, 7, 21)
+        observed_at = DateTime(2026, 7, 22, 12)
+        meta_payload = [(
+            permaTicker = "perm-existing",
+            ticker = "EXIST",
+            isActive = true,
+            isADR = false,
+            dailyLastUpdated = string(observed_at),
+        )]
+        universe_payload = [(
+            ticker = "EXIST",
+            exchange = "NYSE",
+            assetType = "Stock",
+            startDate = "2020-01-01",
+            endDate = "2026-07-22",
+        )]
+        seeded_fetcher = function (ticker; kwargs...)
+            return [(date = string(as_of), marketCap = 10.0)]
+        end
+        sync_fundamentals!(
+            conn,
+            meta_payload,
+            universe_payload;
+            api_key = "offline-token",
+            as_of,
+            observed_at,
+            fetched_at = observed_at,
+            daily_fetcher = seeded_fetcher,
+        )
+        empty_fetcher = function (ticker; kwargs...)
+            return NamedTuple[]
+        end
+
+        result = sync_fundamentals!(
+            conn,
+            meta_payload,
+            universe_payload;
+            api_key = "offline-token",
+            as_of = as_of + Day(1),
+            observed_at = observed_at + Day(1),
+            fetched_at = observed_at + Day(1),
+            daily_fetcher = empty_fetcher,
+        )
+
+        @test result.unchanged == ["perm-existing"]
+        @test isempty(result.unavailable)
+        @test isempty(result.failed)
+    finally
+        close_duckdb(conn)
+    end
+end
+
+@testset "Daily Fundamentals request errors remain retryable failures" begin
+    conn = connect_duckdb(":memory:")
+    try
+        as_of = Date(2026, 7, 19)
+        observed_at = DateTime(2026, 7, 19, 12)
+        meta_payload = [(
+            permaTicker = "perm-error",
+            ticker = "ERROR",
+            isActive = true,
+            isADR = false,
+            dailyLastUpdated = string(observed_at),
+        )]
+        universe_payload = [(
+            ticker = "ERROR",
+            exchange = "NASDAQ",
+            assetType = "Stock",
+            startDate = "2020-01-01",
+            endDate = string(as_of),
+        )]
+        error_fetcher = function (ticker; kwargs...)
+            error("temporary API failure")
+        end
+
+        result = sync_fundamentals!(
+            conn,
+            meta_payload,
+            universe_payload;
+            api_key = "offline-token",
+            as_of,
+            observed_at,
+            fetched_at = observed_at,
+            daily_fetcher = error_fetcher,
+        )
+
+        @test isempty(result.unavailable)
+        @test result.failed == ["perm-error"]
     finally
         close_duckdb(conn)
     end

--- a/test/test_refresh_table_contract.jl
+++ b/test/test_refresh_table_contract.jl
@@ -1,0 +1,225 @@
+using Test
+using DataFrames
+using DuckDB
+using DBInterface
+using TiingoJulia
+
+refresh_script = joinpath(@__DIR__, "..", "scripts", "refresh_postgres_via_duckdb.jl")
+include(refresh_script)
+
+@testset "Refresh table contract" begin
+    @test TABLES_TO_HYDRATE == [
+        "historical_data",
+        "security_observations",
+        "fundamental_daily_metrics",
+    ]
+    @test TABLES_TO_EXPORT == [
+        "historical_data",
+        "us_tickers_filtered",
+        "security_observations",
+        "fundamental_daily_metrics",
+    ]
+
+    conn = connect_duckdb(":memory:")
+    try
+        DBInterface.execute(
+            conn,
+            "INSERT INTO historical_data (ticker, date) VALUES ('AAPL', '2024-01-31')",
+        )
+        DBInterface.execute(conn, """
+            INSERT INTO security_observations (
+                perma_ticker, observed_at, ticker, is_active, join_status
+            ) VALUES (
+                'perm-aapl', '2026-07-19 12:00:00', 'AAPL', true, 'matched'
+            )
+        """)
+        DBInterface.execute(conn, """
+            INSERT INTO fundamental_daily_metrics (
+                perma_ticker, metric_date, fetched_at
+            ) VALUES (
+                'perm-aapl', '2024-01-31', '2026-07-19 12:00:00'
+            )
+        """)
+
+        hydrated_counts = Dict(table => 1 for table in TABLES_TO_HYDRATE)
+        @test verify_hydrated_row_counts!(conn, hydrated_counts) == hydrated_counts
+
+        dropped_counts = copy(hydrated_counts)
+        dropped_counts["security_observations"] = 2
+        @test_throws ErrorException verify_hydrated_row_counts!(conn, dropped_counts)
+    finally
+        close_duckdb(conn)
+    end
+end
+
+@testset "Attached source fundamentals hydrate deterministically" begin
+    source_path = tempname() * ".duckdb"
+    source = DBInterface.connect(DuckDB.DB, source_path)
+    try
+        DBInterface.execute(source, """
+            CREATE TABLE security_observations (
+                perma_ticker VARCHAR,
+                observed_at TIMESTAMP,
+                ticker VARCHAR,
+                is_active BOOLEAN,
+                is_adr BOOLEAN,
+                daily_last_updated TIMESTAMP,
+                exchange VARCHAR,
+                asset_type VARCHAR,
+                price_coverage_start DATE,
+                price_coverage_end DATE,
+                is_leveraged BOOLEAN,
+                join_status VARCHAR
+            )
+        """)
+        DBInterface.execute(source, """
+            INSERT INTO security_observations VALUES (
+                'perm-aapl', '2026-07-19 12:00:00', 'AAPL', true, false,
+                '2026-07-18 12:00:00', 'NASDAQ', 'Stock', '1980-12-12',
+                '2026-07-19', NULL, 'matched'
+            )
+        """)
+        DBInterface.execute(source, """
+            CREATE TABLE fundamental_daily_metrics (
+                perma_ticker VARCHAR,
+                metric_date DATE,
+                market_cap DOUBLE,
+                enterprise_value DOUBLE,
+                pe_ratio DOUBLE,
+                available_at TIMESTAMP,
+                fetched_at TIMESTAMP,
+                source_revision VARCHAR
+            )
+        """)
+        DBInterface.execute(source, """
+            INSERT INTO fundamental_daily_metrics VALUES (
+                'perm-aapl', '2024-01-31', 1.0e10, NULL, NULL,
+                NULL, '2026-07-19 12:00:00', 'rev-1'
+            )
+        """)
+    finally
+        DBInterface.close!(source)
+    end
+
+    conn = connect_duckdb(":memory:")
+    try
+        DBInterface.execute(conn, "ATTACH '$source_path' AS pg_src (READ_ONLY)")
+        security_count = hydrate_attached_table!(
+            conn,
+            "security_observations",
+            [
+                "perma_ticker", "observed_at", "ticker", "is_active", "is_adr",
+                "daily_last_updated", "exchange", "asset_type",
+                "price_coverage_start", "price_coverage_end", "is_leveraged",
+                "join_status",
+            ],
+        )
+        metrics_count = hydrate_attached_table!(
+            conn,
+            "fundamental_daily_metrics",
+            [
+                "perma_ticker", "metric_date", "market_cap", "enterprise_value",
+                "pe_ratio", "available_at", "fetched_at", "source_revision",
+            ],
+        )
+
+        @test security_count == 1
+        @test metrics_count == 1
+        @test (DBInterface.execute(conn, "SELECT count(*) FROM security_observations") |> DataFrame)[1, 1] == 1
+        @test (
+            DBInterface.execute(conn, "SELECT count(*) FROM fundamental_daily_metrics") |>
+            DataFrame
+        )[1, 1] == 1
+    finally
+        try
+            DBInterface.execute(conn, "DETACH pg_src")
+        catch
+        end
+        close_duckdb(conn)
+        rm(source_path; force=true)
+    end
+end
+
+@testset "Resumable Fundamentals merge preserves local and PostgreSQL keys" begin
+    source_path = tempname() * ".duckdb"
+    source = connect_duckdb(source_path)
+    try
+        DBInterface.execute(source, """
+            INSERT INTO security_observations (
+                perma_ticker, observed_at, ticker, is_active, exchange, join_status
+            ) VALUES
+                ('perm-existing', '2026-07-19 12:00:00', 'OLD', true, 'PG', 'matched'),
+                ('perm-new', '2026-07-20 12:00:00', 'NEW', true, 'PG', 'matched')
+        """)
+        DBInterface.execute(source, """
+            INSERT INTO fundamental_daily_metrics (
+                perma_ticker, metric_date, market_cap, fetched_at
+            ) VALUES
+                ('perm-existing', '2026-07-18', 10.0, '2026-07-19 12:00:00'),
+                ('perm-new', '2026-07-19', 20.0, '2026-07-20 12:00:00')
+        """)
+    finally
+        close_duckdb(source)
+    end
+
+    conn = connect_duckdb(":memory:")
+    try
+        DBInterface.execute(conn, """
+            INSERT INTO security_observations (
+                perma_ticker, observed_at, ticker, is_active, exchange, join_status
+            ) VALUES (
+                'perm-existing', '2026-07-19 12:00:00', 'LOCAL', true, 'LOCAL', 'matched'
+            )
+        """)
+        DBInterface.execute(conn, """
+            INSERT INTO fundamental_daily_metrics (
+                perma_ticker, metric_date, market_cap, fetched_at
+            ) VALUES (
+                'perm-existing', '2026-07-18', 99.0, '2026-07-20 12:00:00'
+            )
+        """)
+        DBInterface.execute(conn, "ATTACH '$source_path' AS pg_src (READ_ONLY)")
+
+        security_count = merge_attached_table!(
+            conn,
+            "security_observations",
+            [
+                "perma_ticker", "observed_at", "ticker", "is_active", "is_adr",
+                "daily_last_updated", "exchange", "asset_type",
+                "price_coverage_start", "price_coverage_end", "is_leveraged",
+                "join_status",
+            ],
+            ["perma_ticker", "observed_at"],
+        )
+        metrics_count = merge_attached_table!(
+            conn,
+            "fundamental_daily_metrics",
+            [
+                "perma_ticker", "metric_date", "market_cap", "enterprise_value",
+                "pe_ratio", "available_at", "fetched_at", "source_revision",
+            ],
+            ["perma_ticker", "metric_date"],
+        )
+
+        @test security_count == 2
+        @test metrics_count == 2
+        securities = DBInterface.execute(
+            conn,
+            "SELECT ticker, exchange FROM security_observations ORDER BY perma_ticker",
+        ) |> DataFrame
+        @test securities.ticker == ["LOCAL", "NEW"]
+        @test securities.exchange == ["LOCAL", "PG"]
+        metrics = DBInterface.execute(
+            conn,
+            "SELECT market_cap FROM fundamental_daily_metrics ORDER BY perma_ticker",
+        ) |> DataFrame
+        @test metrics.market_cap == [99.0, 20.0]
+    finally
+        try
+            DBInterface.execute(conn, "DETACH pg_src")
+        catch
+        end
+        close_duckdb(conn)
+        rm(source_path; force=true)
+    end
+end

--- a/test/test_refresh_table_contract.jl
+++ b/test/test_refresh_table_contract.jl
@@ -7,6 +7,34 @@ using TiingoJulia
 refresh_script = joinpath(@__DIR__, "..", "scripts", "refresh_postgres_via_duckdb.jl")
 include(refresh_script)
 
+@testset "Fundamentals entitlement probe falls back across current candidates" begin
+    observations = DataFrame(
+        perma_ticker = ["perm-empty", "perm-ok"],
+        ticker = ["EMPTY", "GOOGL"],
+        is_active = [true, true],
+        asset_type = ["Stock", "Stock"],
+        join_status = ["matched", "matched"],
+        daily_last_updated = [
+            DateTime(2026, 7, 22, 2),
+            DateTime(2026, 7, 22, 1),
+        ],
+    )
+    calls = String[]
+    daily_fetcher = function (ticker; api_key, start_date, end_date, columns, return_type)
+        push!(calls, ticker)
+        ticker == "perm-empty" && return NamedTuple[]
+        return [(date = "2026-07-21", marketCap = 1.0)]
+    end
+
+    @test isnothing(verify_fundamentals_entitlement!(
+        observations,
+        "offline-token";
+        as_of = Date(2026, 7, 22),
+        daily_fetcher,
+    ))
+    @test calls == ["perm-empty", "perm-ok"]
+end
+
 @testset "Refresh table contract" begin
     @test TABLES_TO_HYDRATE == [
         "historical_data",


### PR DESCRIPTION
Adds resumable market-cap fundamentals backfill. Branch is post-scrub (merge-base #595, 2026-07-18); only behind main by the setup-python bump #596.