### PR TITLE
fix(fundamentals): export within a failure tolerance instead of all-or-nothing

### DIFF
--- a/scripts/backfill_fundamentals.jl
+++ b/scripts/backfill_fundamentals.jl
@@ -134,13 +134,22 @@ function main()
             observed_at,
             fetched_at=observed_at,
         )
-        if !isempty(result.failed)
-            println("FUNDAMENTALS_BACKFILL_PARTIAL failed=$(length(result.failed)) completed=$(length(result.requested)) resume_path=$duckdb_path")
-            exit(2)
-        end
+        failed_count = length(result.failed)
+
+        # Tolerate a small number of per-security failures. The export REPLACES the
+        # PostgreSQL tables (staging + atomic swap), so a widespread failure — an API
+        # outage — must NOT export: it would clobber good market caps with a nearly
+        # empty snapshot. But a handful of persistently-bad securities (delisted, no
+        # data, one-off API quirks) must not block caps for the other thousands, which
+        # is exactly what the old all-or-nothing gate did (one failure in ~5,300 left
+        # security_observations uncreated and every cap-dependent screener empty).
+        # Above the threshold we skip the export and keep yesterday's snapshot intact.
+        max_export_failures = parse(Int, get(ENV, "FUNDAMENTALS_MAX_EXPORT_FAILURES", "100"))
+        within_tolerance = failed_count <= max_export_failures
 
         counts = validate_backfill!(conn, as_of)
-        if do_export
+        exported = false
+        if do_export && within_tolerance
             pg_conn = connect_postgres(pg_conn_str)
             try
                 export_to_postgres(
@@ -149,11 +158,21 @@ function main()
                     ["security_observations", "fundamental_daily_metrics"];
                     pg_connection_string=pg_conn_str,
                 )
+                exported = true
             finally
                 close_postgres(pg_conn)
             end
         end
-        println("FUNDAMENTALS_BACKFILL_OK requested=$(length(result.requested)) skipped=$(length(result.skipped)) unchanged=$(length(result.unchanged)) unavailable=$(length(result.unavailable)) observations=$(counts.observations) metrics=$(counts.metrics) exported=$do_export")
+
+        if failed_count > 0
+            # exit 2 = partial but the good rows WERE exported (alert, not data loss);
+            # exit 3 = failures exceeded tolerance so the export was withheld to protect
+            # the existing snapshot (more urgent). Both keep the DuckDB for watermark
+            # resume on the next run.
+            println("FUNDAMENTALS_BACKFILL_PARTIAL failed=$(failed_count) completed=$(length(result.requested)) unchanged=$(length(result.unchanged)) unavailable=$(length(result.unavailable)) exported=$(exported) resume_path=$duckdb_path")
+            exit(within_tolerance ? 2 : 3)
+        end
+        println("FUNDAMENTALS_BACKFILL_OK requested=$(length(result.requested)) skipped=$(length(result.skipped)) unchanged=$(length(result.unchanged)) unavailable=$(length(result.unavailable)) observations=$(counts.observations) metrics=$(counts.metrics) exported=$exported")
     finally
         close_duckdb(conn)
     end


### PR DESCRIPTION
## Problem

On data-plane the daily fundamentals sync refused the PostgreSQL export whenever **any** eligible security failed:

```
FUNDAMENTALS_BACKFILL_PARTIAL failed=1 completed=47   → exit 2, export refused
```

One persistently-bad security out of ~5,300 (delisted, no data, a one-off API error) was enough to leave `security_observations` uncreated — so QuantScreener's cap-dependent universes (`:sctr`, `:atgl`) stayed empty and ATGL reported 0 signals. In steady state, a transient blip on any single security would do the same intermittently.

## Why the gate existed (and why it over-protects)

The export **REPLACES** the PG tables (staging table + atomic swap in `export_table_to_postgres_dataframe`). So exporting during a *widespread* failure — a Tiingo API outage — would clobber good market caps with a near-empty snapshot. All-or-nothing prevented that. But it also blocked the export for the other ~5,299 securities when just one failed.

## Change

Replace the gate with a tolerance, `FUNDAMENTALS_MAX_EXPORT_FAILURES` (default **100**, ~2% of the eligible universe):

| failures | behaviour | exit |
|---|---|---|
| 0 | export | 0 |
| 1 … threshold | **export the good rows**, alert | 2 |
| > threshold | **skip export**, keep yesterday's snapshot | 3 |

Both partial paths keep the working DuckDB so the next run resumes from each security's watermark. The `FUNDAMENTALS_BACKFILL_PARTIAL` line now reports `exported=true/false`.

## Evidence

Measured on data-plane: first run 48 failures (mostly transient), watermark-resume rerun **1**. Under the old gate that 1 blocked everything; under this change the 5,272 good securities export and ATGL can populate.

## Reviewer notes

- Export idempotence: because it's a full replace, exporting a partial snapshot daily is safe — no duplication, each run is a fresh snapshot of whatever succeeded.
- The threshold protects the real risk (outage → empty overwrite) while unblocking the common case (a few dead tickers).
- Pairs with quansift_scheduler#(exit-codes PR): the wrapper now distinguishes exit 2 (partial, exported) from exit 3 (withheld). Land this first.

## Test plan

- [x] Script loads/parses under `using TiingoJulia` (main defined, guard intact)
- [ ] Re-run on data-plane: `failed=1` now yields `exit 2 … exported=true`, and `SELECT count(*) FROM security_observations` is non-zero
- [ ] Then ATGL reports `num_tickers > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)