### PR TITLE
fix: map DuckDB DECIMAL to PostgreSQL NUMERIC in legacy export

### DIFF
--- a/src/db/schema.jl
+++ b/src/db/schema.jl
@@ -268,6 +268,14 @@ module Schema
         return query
     end
 
+    # DECIMAL(p, s) / NUMERIC(p, s). Precision and scale are digits only, and the
+    # returned type is rebuilt from the parsed integers, so no caller-supplied
+    # text ever reaches the generated DDL.
+    const DECIMAL_TYPE_PATTERN = r"^(?:DECIMAL|NUMERIC)\(\s*(\d{1,4})\s*,\s*(\d{1,4})\s*\)$"
+
+    # PostgreSQL rejects NUMERIC precision outside 1..1000.
+    const MAX_NUMERIC_PRECISION = 1000
+
     """
         map_duckdb_to_postgres_type(duckdb_type::String)
 
@@ -286,10 +294,20 @@ module Schema
         )
 
         normalized_type = uppercase(strip(duckdb_type))
-        haskey(type_mapping, normalized_type) || throw(ArgumentError(
+        haskey(type_mapping, normalized_type) && return type_mapping[normalized_type]
+
+        decimal_match = match(DECIMAL_TYPE_PATTERN, normalized_type)
+        if decimal_match !== nothing
+            precision = parse(Int, decimal_match.captures[1])
+            scale = parse(Int, decimal_match.captures[2])
+            if 1 <= precision <= MAX_NUMERIC_PRECISION && 0 <= scale <= precision
+                return "NUMERIC($(precision), $(scale))"
+            end
+        end
+
+        throw(ArgumentError(
             "Unsupported DuckDB type for PostgreSQL export: '$duckdb_type'",
         ))
-        return type_mapping[normalized_type]
     end
     export create_tables, create_indexes, create_or_replace_table, list_tables
     export generate_create_table_query, map_duckdb_to_postgres_type

--- a/test/test_postgres_legacy_sql_safety.jl
+++ b/test/test_postgres_legacy_sql_safety.jl
@@ -76,7 +76,18 @@ end
         @test map_duckdb_to_postgres_type(duckdb_type) == postgres_type
     end
 
-    @test_throws ArgumentError map_duckdb_to_postgres_type("DECIMAL(18, 2)")
+    # Screener output tables are NUMERIC(p, s) in PostgreSQL, so the artifact
+    # Parquet round-trips as DECIMAL(p, s) through DuckDB's DESCRIBE.
+    @test map_duckdb_to_postgres_type("DECIMAL(12,4)") == "NUMERIC(12, 4)"
+    @test map_duckdb_to_postgres_type(" decimal(18, 2) ") == "NUMERIC(18, 2)"
+    @test map_duckdb_to_postgres_type("NUMERIC(8,4)") == "NUMERIC(8, 4)"
+
+    @test_throws ArgumentError map_duckdb_to_postgres_type("DECIMAL(4, 9)")
+    @test_throws ArgumentError map_duckdb_to_postgres_type("DECIMAL(0, 0)")
+    @test_throws ArgumentError map_duckdb_to_postgres_type("DECIMAL(12)")
+    @test_throws ArgumentError map_duckdb_to_postgres_type(
+        "DECIMAL(12,4)); DROP TABLE historical_data; --",
+    )
     @test_throws ArgumentError map_duckdb_to_postgres_type("INTEGER[]")
     @test_throws ArgumentError map_duckdb_to_postgres_type("UBIGINT")
     @test_throws ArgumentError map_duckdb_to_postgres_type(


### PR DESCRIPTION
## Problem

`prod_load` fails for every screener table in the daily artifact:

```
ERROR: LoadError: ArgumentError: Unsupported DuckDB type for PostgreSQL export: 'DECIMAL(12,4)'
```

Chain:

1. `QuantScreener/sql/init_quantscreener.sql` defines screener outputs with `price NUMERIC(12, 4)` (also `(8,4)`, `(12,6)`).
2. `publish_results.sh` exports those tables to the artifact Parquet, preserving the decimal logical type.
3. `quansift_scheduler/scripts/prod_load.jl` runs `DESCRIBE SELECT * FROM read_parquet(...)`, which reports `DECIMAL(12,4)`, and passes that schema to `generate_create_table_query`.
4. `map_duckdb_to_postgres_type` allowlisted only 8 exact type names, so it threw.

The quality gate runs before any table swap, so production tables were never touched — but no screener artifact could reach Managed PG.

## Fix

`map_duckdb_to_postgres_type` now also accepts `DECIMAL(p, s)` / `NUMERIC(p, s)` and returns `NUMERIC(p, s)`.

The allowlist exists because the mapped type is string-concatenated into `CREATE TABLE`, so widening it needed care:

- precision and scale are matched as digits only (`\d{1,4}`), anchored `^...$`;
- the returned type is rebuilt from the parsed `Int`s — no caller-supplied text reaches the DDL;
- precision outside `1..1000` (PostgreSQL's limit), `scale > precision`, bare `DECIMAL(12)`, and any trailing text are still rejected.

Behaviour for the 8 existing types is unchanged.

## Test plan

- [x] `julia --project=. test/test_postgres_legacy_sql_safety.jl` — 26/26 pass. The type-mapping testset grew 12 -> 18: accept cases for `DECIMAL(12,4)`, ` decimal(18, 2) `, `NUMERIC(8,4)`; reject cases for `DECIMAL(4, 9)`, `DECIMAL(0, 0)`, `DECIMAL(12)`, and a trailing-SQL injection string.
- [x] End-to-end smoke on the real path: wrote a Parquet with `DECIMAL(12,4)` / `DECIMAL(8,4)` columns, ran `DESCRIBE read_parquet(...)` then `generate_create_table_query`, got

      CREATE TABLE IF NOT EXISTS "public"."golden_cross_outputs_staging" ("ticker" VARCHAR, "price" NUMERIC(12, 4), "rs" NUMERIC(8, 4), "signal_date" DATE)

- [ ] Full `Pkg.test()` in CI.
- [ ] After merge: `./scripts/prod_load.sh --date <date>` on the data plane. Remove `prod_load_<date>.marker` first, since a prior run marks the date as loaded and the script no-ops.
