### PR TITLE
fix(postgres): migrate compatibility exports

### DIFF
--- a/src/db/migrations.jl
+++ b/src/db/migrations.jl
@@ -257,9 +257,71 @@ end
 
 const POSTGRES_V1_0_MANIFEST = _v1_manifest()
 const POSTGRES_TARGET_MANIFEST = _target_manifest()
+
+function _compatibility_export_manifest()
+    historical_columns = vcat(
+        [
+            PostgresColumnManifest("ticker", :varchar, false),
+            PostgresColumnManifest("date", :date, false),
+        ],
+        [
+            PostgresColumnManifest(
+                column.name,
+                column.data_type == :float8 ? :float4 : column.data_type,
+                true,
+            )
+            for column in _HISTORICAL_VALUE_COLUMNS
+        ],
+    )
+    observation_columns = [
+        PostgresColumnManifest("perma_ticker", :varchar, false),
+        PostgresColumnManifest("observed_at", :timestamp, false),
+        PostgresColumnManifest("ticker", :varchar, true),
+        PostgresColumnManifest("is_active", :boolean, true),
+        PostgresColumnManifest("is_adr", :boolean, true),
+        PostgresColumnManifest("daily_last_updated", :timestamp, true),
+        PostgresColumnManifest("exchange", :varchar, true),
+        PostgresColumnManifest("asset_type", :varchar, true),
+        PostgresColumnManifest("price_coverage_start", :date, true),
+        PostgresColumnManifest("price_coverage_end", :date, true),
+        PostgresColumnManifest("is_leveraged", :boolean, true),
+        PostgresColumnManifest("join_status", :varchar, true),
+    ]
+    metric_columns = [
+        PostgresColumnManifest("perma_ticker", :varchar, false),
+        PostgresColumnManifest("metric_date", :date, false),
+        PostgresColumnManifest("market_cap", :float8, true),
+        PostgresColumnManifest("enterprise_value", :float8, true),
+        PostgresColumnManifest("pe_ratio", :float8, true),
+        PostgresColumnManifest("available_at", :timestamp, true),
+        PostgresColumnManifest("fetched_at", :timestamp, true),
+        PostgresColumnManifest("source_revision", :varchar, true),
+    ]
+    return PostgresDatabaseManifest(Dict(
+        "historical_data" => _relation(
+            "historical_data",
+            historical_columns,
+            [_index("ticker", "date"; unique=true, primary=true)],
+        ),
+        "us_tickers_filtered" => _relation("us_tickers_filtered", _TICKER_COLUMNS),
+        "security_observations" => _relation(
+            "security_observations",
+            observation_columns,
+            [_index("perma_ticker", "observed_at"; unique=true, primary=true)],
+        ),
+        "fundamental_daily_metrics" => _relation(
+            "fundamental_daily_metrics",
+            metric_columns,
+            [_index("perma_ticker", "metric_date"; unique=true, primary=true)],
+        ),
+    ))
+end
+
+const POSTGRES_COMPATIBILITY_EXPORT_MANIFEST = _compatibility_export_manifest()
 const POSTGRES_LEGACY_CATALOG = Dict(
     :fresh => "no canonical application relations",
     :released_1_0_export => "released 1.0 export subset",
+    :first_party_compatibility_export => "first-party compatibility export",
     :released_1_0_plus_preledger_bootstrap => "released 1.0/current hybrid",
     :current_1_1_preledger => "current pre-ledger schema",
 )
@@ -514,6 +576,11 @@ function classify_preledger_manifest(manifest::PostgresDatabaseManifest)::Symbol
     isempty(manifest.relations) && return :fresh
     _manifest_matches(manifest, POSTGRES_TARGET_MANIFEST) &&
         return :current_1_1_preledger
+    _manifest_matches(
+        manifest,
+        POSTGRES_COMPATIBILITY_EXPORT_MANIFEST;
+        exact_indexes=true,
+    ) && return :first_party_compatibility_export
     _is_released_v1_subset(manifest) && return :released_1_0_export
     _is_preledger_hybrid(manifest) &&
         return :released_1_0_plus_preledger_bootstrap
@@ -979,6 +1046,48 @@ function _assert_legacy_historical_keys!(conn)
     return nothing
 end
 
+function _upgrade_compatibility_export!(conn)
+    invalid = _pg_dataframe(conn, """
+        SELECT
+          (SELECT count(*) FROM "public"."security_observations"
+           WHERE ticker IS NULL OR is_active IS NULL OR join_status IS NULL)
+            AS observation_nulls,
+          (SELECT count(*) FROM "public"."fundamental_daily_metrics"
+           WHERE fetched_at IS NULL) AS metric_nulls
+    """)
+    (Int(invalid.observation_nulls[1]) == 0 && Int(invalid.metric_nulls[1]) == 0) ||
+        throw(PostgresMigrationError(
+            1,
+            "canonical_v1_baseline",
+            "compatibility export has null required values; " *
+            "take a backup and repair explicitly",
+        ))
+    _pg_command(conn, """
+        ALTER TABLE "public"."historical_data"
+          ALTER COLUMN close TYPE DOUBLE PRECISION,
+          ALTER COLUMN high TYPE DOUBLE PRECISION,
+          ALTER COLUMN low TYPE DOUBLE PRECISION,
+          ALTER COLUMN open TYPE DOUBLE PRECISION,
+          ALTER COLUMN adjclose TYPE DOUBLE PRECISION,
+          ALTER COLUMN adjhigh TYPE DOUBLE PRECISION,
+          ALTER COLUMN adjlow TYPE DOUBLE PRECISION,
+          ALTER COLUMN adjopen TYPE DOUBLE PRECISION,
+          ALTER COLUMN divcash TYPE DOUBLE PRECISION,
+          ALTER COLUMN splitfactor TYPE DOUBLE PRECISION
+    """)
+    _pg_command(conn, """
+        ALTER TABLE "public"."security_observations"
+          ALTER COLUMN ticker SET NOT NULL,
+          ALTER COLUMN is_active SET NOT NULL,
+          ALTER COLUMN join_status SET NOT NULL
+    """)
+    _pg_command(conn, """
+        ALTER TABLE "public"."fundamental_daily_metrics"
+          ALTER COLUMN fetched_at SET NOT NULL
+    """)
+    return nothing
+end
+
 function _has_primary_historical_key(manifest::PostgresDatabaseManifest)
     haskey(manifest.relations, "historical_data") || return false
     return any(
@@ -988,6 +1097,8 @@ function _has_primary_historical_key(manifest::PostgresDatabaseManifest)
 end
 
 function _apply_bootstrap_transition!(conn, catalog_entry::Symbol, manifest)
+    catalog_entry == :first_party_compatibility_export &&
+        _upgrade_compatibility_export!(conn)
     for statement in POSTGRES_TARGET_DDL
         _pg_command(conn, statement)
     end

--- a/test/test_postgres_integration.jl
+++ b/test/test_postgres_integration.jl
@@ -91,6 +91,88 @@ function _pg_integration_create_current_preledger(conn)
     return nothing
 end
 
+function _pg_integration_create_compatibility_export(conn)
+    schemas = Dict(
+        "historical_data" => DataFrame(
+            column_name=[
+                "ticker", "date", "close", "high", "low", "open", "volume",
+                "adjClose", "adjHigh", "adjLow", "adjOpen", "adjVolume",
+                "divCash", "splitFactor",
+            ],
+            column_type=[
+                "VARCHAR", "DATE", "FLOAT", "FLOAT", "FLOAT", "FLOAT",
+                "BIGINT", "FLOAT", "FLOAT", "FLOAT", "FLOAT", "BIGINT",
+                "FLOAT", "FLOAT",
+            ],
+        ),
+        "us_tickers_filtered" => DataFrame(
+            column_name=[
+                "ticker", "exchange", "assetType", "priceCurrency", "startDate",
+                "endDate",
+            ],
+            column_type=["VARCHAR", "VARCHAR", "VARCHAR", "VARCHAR", "DATE", "DATE"],
+        ),
+        "security_observations" => DataFrame(
+            column_name=[
+                "perma_ticker", "observed_at", "ticker", "is_active", "is_adr",
+                "daily_last_updated", "exchange", "asset_type",
+                "price_coverage_start", "price_coverage_end", "is_leveraged",
+                "join_status",
+            ],
+            column_type=[
+                "VARCHAR", "TIMESTAMP", "VARCHAR", "BOOLEAN", "BOOLEAN",
+                "TIMESTAMP", "VARCHAR", "VARCHAR", "DATE", "DATE", "BOOLEAN",
+                "VARCHAR",
+            ],
+        ),
+        "fundamental_daily_metrics" => DataFrame(
+            column_name=[
+                "perma_ticker", "metric_date", "market_cap", "enterprise_value",
+                "pe_ratio", "available_at", "fetched_at", "source_revision",
+            ],
+            column_type=[
+                "VARCHAR", "DATE", "DOUBLE", "DOUBLE", "DOUBLE", "TIMESTAMP",
+                "TIMESTAMP", "VARCHAR",
+            ],
+        ),
+    )
+    for name in (
+        "historical_data",
+        "us_tickers_filtered",
+        "security_observations",
+        "fundamental_daily_metrics",
+    )
+        _pg_integration_command(
+            conn,
+            MigrationSchemaIntegration.generate_create_table_query(name, schemas[name]),
+        )
+    end
+    _pg_integration_command(conn, """
+        INSERT INTO public.historical_data
+          (ticker, date, close, high, low, open, volume, adjclose, adjhigh,
+           adjlow, adjopen, adjvolume, divcash, splitfactor)
+        VALUES ('EXPORTED', DATE '2024-02-03', 0.1, 0.2, 0.3, 0.4, 123,
+                0.5, 0.6, 0.7, 0.8, 456, 0.9, 1.1)
+    """)
+    _pg_integration_command(conn, """
+        INSERT INTO public.us_tickers_filtered
+          (ticker, exchange, assettype, pricecurrency, startdate, enddate)
+        VALUES ('EXPORTED', 'NASDAQ', 'Stock', 'USD',
+                DATE '2024-01-01', DATE '2024-12-31')
+    """)
+    _pg_integration_command(conn, """
+        INSERT INTO public.security_observations
+          (perma_ticker, observed_at, ticker, is_active, join_status)
+        VALUES ('PERMA', TIMESTAMP '2024-02-03 12:00:00', 'EXPORTED', true, 'matched')
+    """)
+    _pg_integration_command(conn, """
+        INSERT INTO public.fundamental_daily_metrics
+          (perma_ticker, metric_date, market_cap, fetched_at)
+        VALUES ('PERMA', DATE '2024-02-03', 100.5, TIMESTAMP '2024-02-04 12:00:00')
+    """)
+    return nothing
+end
+
 function _pg_integration_assert_legacy_rows(conn, names)
     for name in names
         if name == "historical_data"
@@ -227,9 +309,125 @@ pg_connection_string = get(ENV, "TIINGO_TEST_PG_CONNECTION", "")
                     "SELECT close FROM public.historical_data " *
                     "WHERE ticker = 'CURRENT'",
                 ).close) == 88.0
+
+                _pg_integration_cleanup(pg)
+                _pg_integration_create_compatibility_export(pg)
+                unchanged_export_tables = (
+                    "us_tickers_filtered",
+                    "security_observations",
+                    "fundamental_daily_metrics",
+                )
+                before_export = Dict(name => only(_pg_integration_query(
+                    pg,
+                    "SELECT md5(string_agg(to_jsonb(t)::text, '' " *
+                    "ORDER BY to_jsonb(t)::text)) AS fingerprint " *
+                    "FROM public.$name t",
+                ).fingerprint) for name in unchanged_export_tables)
+                historical_stable_sql = """
+                    SELECT md5(string_agg(
+                        to_jsonb(ROW(ticker, date, volume, adjvolume))::text,
+                        '' ORDER BY ticker, date
+                    )) AS fingerprint
+                    FROM public.historical_data
+                """
+                historical_real_sql = """
+                    SELECT close::REAL, high::REAL, low::REAL, open::REAL,
+                           adjclose::REAL, adjhigh::REAL, adjlow::REAL,
+                           adjopen::REAL, divcash::REAL, splitfactor::REAL
+                    FROM public.historical_data
+                    ORDER BY ticker, date
+                """
+                historical_stable_before = only(_pg_integration_query(
+                    pg,
+                    historical_stable_sql,
+                ).fingerprint)
+                historical_real_before = _pg_integration_query(pg, historical_real_sql)
+                @test MigrationSchemaIntegration.classify_preledger_manifest(
+                    MigrationSchemaIntegration.inspect_postgres_manifest(pg),
+                ) == :first_party_compatibility_export
+                @test migrate_postgres!(pg).applied_versions == [1]
+                after_export = Dict(name => only(_pg_integration_query(
+                    pg,
+                    "SELECT md5(string_agg(to_jsonb(t)::text, '' " *
+                    "ORDER BY to_jsonb(t)::text)) AS fingerprint " *
+                    "FROM public.$name t",
+                ).fingerprint) for name in unchanged_export_tables)
+                @test after_export == before_export
+                @test only(_pg_integration_query(
+                    pg,
+                    historical_stable_sql,
+                ).fingerprint) == historical_stable_before
+                @test _pg_integration_query(pg, historical_real_sql) ==
+                      historical_real_before
+                @test migrate_postgres!(pg).applied_versions == Int[]
+
+                export_owner = "tiingo_test_export_owner"
+                _pg_integration_cleanup(pg)
+                _pg_integration_command(pg, "DROP ROLE IF EXISTS $export_owner")
+                _pg_integration_command(pg, "CREATE ROLE $export_owner NOLOGIN")
+                try
+                    _pg_integration_command(
+                        pg,
+                        "GRANT CREATE ON SCHEMA public TO $export_owner",
+                    )
+                    _pg_integration_create_compatibility_export(pg)
+                    for name in (
+                        "historical_data",
+                        unchanged_export_tables...,
+                    )
+                        _pg_integration_command(
+                            pg,
+                            "ALTER TABLE public.$name OWNER TO $export_owner",
+                        )
+                    end
+                    @test_throws PostgresMigrationError migrate_postgres!(pg)
+                    _pg_integration_command(pg, "SET ROLE $export_owner")
+                    @test migrate_postgres!(pg).applied_versions == [1]
+                    @test postgres_schema_version(pg) == 1
+                finally
+                    _pg_integration_command(pg, "RESET ROLE")
+                    _pg_integration_cleanup(pg)
+                    _pg_integration_command(
+                        pg,
+                        "REVOKE CREATE ON SCHEMA public FROM $export_owner",
+                    )
+                    _pg_integration_command(pg, "DROP ROLE IF EXISTS $export_owner")
+                end
             end
 
             @testset "PostgreSQL migration fail-closed ledger and rollback" begin
+                _pg_integration_cleanup(pg)
+                _pg_integration_create_compatibility_export(pg)
+                _pg_integration_command(
+                    pg,
+                    "UPDATE public.security_observations SET ticker = NULL",
+                )
+                _pg_integration_command(
+                    pg,
+                    "UPDATE public.fundamental_daily_metrics SET fetched_at = NULL",
+                )
+                @test_throws PostgresMigrationError migrate_postgres!(pg)
+                @test postgres_schema_version(pg) == 0
+                @test ismissing(only(_pg_integration_query(
+                    pg,
+                    "SELECT to_regclass('public.us_tickers') AS relation",
+                ).relation))
+                @test only(_pg_integration_query(
+                    pg,
+                    "SELECT data_type FROM information_schema.columns " *
+                    "WHERE table_schema = 'public' " *
+                    "AND table_name = 'historical_data' AND column_name = 'close'",
+                ).data_type) == "real"
+                @test ismissing(only(_pg_integration_query(
+                    pg,
+                    "SELECT ticker FROM public.security_observations",
+                ).ticker))
+                @test ismissing(only(_pg_integration_query(
+                    pg,
+                    "SELECT fetched_at FROM public.fundamental_daily_metrics",
+                ).fetched_at))
+                @test LibPQ.transaction_status(pg) == LibPQ.libpq_c.PQTRANS_IDLE
+
                 _pg_integration_cleanup(pg)
                 _pg_integration_command(
                     pg,

--- a/test/test_postgres_migrations.jl
+++ b/test/test_postgres_migrations.jl
@@ -78,6 +78,7 @@ end
     @test Set(keys(MigrationSchema.POSTGRES_LEGACY_CATALOG)) == Set([
         :fresh,
         :released_1_0_export,
+        :first_party_compatibility_export,
         :released_1_0_plus_preledger_bootstrap,
         :current_1_1_preledger,
     ])
@@ -96,6 +97,55 @@ end
     @test MigrationSchema.classify_preledger_manifest(
         MigrationSchema.POSTGRES_TARGET_MANIFEST,
     ) == :current_1_1_preledger
+
+    compatibility_export = deepcopy(
+        MigrationSchema.POSTGRES_COMPATIBILITY_EXPORT_MANIFEST,
+    )
+    @test MigrationSchema.classify_preledger_manifest(compatibility_export) ==
+          :first_party_compatibility_export
+    @test compatibility_export.relations["historical_data"].columns[3].data_type ==
+          :float4
+    @test compatibility_export.relations["security_observations"].columns[3].nullable
+    @test compatibility_export.relations["fundamental_daily_metrics"].columns[7].nullable
+
+    for near_miss in (
+        let manifest = deepcopy(compatibility_export)
+            delete!(manifest.relations, "security_observations")
+            manifest
+        end,
+        let manifest = deepcopy(compatibility_export)
+            manifest.relations["us_tickers"] = deepcopy(
+                MigrationSchema.POSTGRES_TARGET_MANIFEST.relations["us_tickers"],
+            )
+            manifest
+        end,
+        let manifest = deepcopy(compatibility_export)
+            manifest.relations["historical_data"].owner_matches_current_role = false
+            manifest
+        end,
+        let manifest = deepcopy(compatibility_export)
+            manifest.relations["historical_data"].row_security = true
+            manifest
+        end,
+        let manifest = deepcopy(compatibility_export)
+            manifest.relations["historical_data"].columns[3] =
+                MigrationSchema.PostgresColumnManifest("close", :float8, true)
+            manifest
+        end,
+        let manifest = deepcopy(compatibility_export)
+            push!(
+                manifest.relations["us_tickers_filtered"].indexes,
+                deepcopy(MigrationSchema.POSTGRES_TARGET_MANIFEST.relations[
+                    "us_tickers_filtered"
+                ].indexes[1]),
+            )
+            manifest
+        end,
+    )
+        @test_throws PostgresMigrationError MigrationSchema.classify_preledger_manifest(
+            near_miss,
+        )
+    end
 
     hostile = deepcopy(MigrationSchema.POSTGRES_TARGET_MANIFEST)
     push!(


### PR DESCRIPTION
## Summary

- recognize the exact four-table PostgreSQL layout produced by the deprecated first-party exporter
- widen historical `REAL` values to `DOUBLE PRECISION` and restore required `NOT NULL` constraints transactionally
- preserve fail-closed owner, RLS, trigger, index, and schema checks

## Root cause

The production restore uses a first-party four-table pre-ledger layout that the v2 finite classifier did not model. It was therefore rejected as unknown before migration. Running the rehearsal as `postgres` also correctly failed the owner-role check; deployment must migrate under `SET ROLE tiingo_user`.

## Validation

- PostgreSQL migration unit tests: 92/92
- PostgreSQL 17 integration: 208/208
- independent review: no remaining P0-P3 findings
- `git diff --check`

The migration-1 checksum is unchanged.
