### PR TITLE
fix(postgres): migrate deployed export

### DIFF
--- a/src/db/migrations.jl
+++ b/src/db/migrations.jl
@@ -318,10 +318,44 @@ function _compatibility_export_manifest()
 end
 
 const POSTGRES_COMPATIBILITY_EXPORT_MANIFEST = _compatibility_export_manifest()
+
+function _deployed_export_manifest()
+    filtered_columns = copy(_TICKER_COLUMNS)
+    filtered_columns[1] = PostgresColumnManifest("ticker", :varchar, false)
+    return PostgresDatabaseManifest(Dict(
+        "historical_data" => _relation(
+            "historical_data",
+            POSTGRES_TARGET_MANIFEST.relations["historical_data"].columns,
+            [_index("ticker", "date"; unique=true, primary=true)],
+        ),
+        "us_tickers_filtered" => _relation(
+            "us_tickers_filtered",
+            filtered_columns,
+            [
+                _index("ticker"; unique=true, primary=true),
+                _index("assettype"),
+                _index("exchange"),
+            ],
+        ),
+        "security_observations" => deepcopy(
+            POSTGRES_COMPATIBILITY_EXPORT_MANIFEST.relations[
+                "security_observations"
+            ],
+        ),
+        "fundamental_daily_metrics" => deepcopy(
+            POSTGRES_COMPATIBILITY_EXPORT_MANIFEST.relations[
+                "fundamental_daily_metrics"
+            ],
+        ),
+    ))
+end
+
+const POSTGRES_DEPLOYED_EXPORT_MANIFEST = _deployed_export_manifest()
 const POSTGRES_LEGACY_CATALOG = Dict(
     :fresh => "no canonical application relations",
     :released_1_0_export => "released 1.0 export subset",
     :first_party_compatibility_export => "first-party compatibility export",
+    :deployed_first_party_composition => "deployed exporter/scheduler composition",
     :released_1_0_plus_preledger_bootstrap => "released 1.0/current hybrid",
     :current_1_1_preledger => "current pre-ledger schema",
 )
@@ -581,6 +615,11 @@ function classify_preledger_manifest(manifest::PostgresDatabaseManifest)::Symbol
         POSTGRES_COMPATIBILITY_EXPORT_MANIFEST;
         exact_indexes=true,
     ) && return :first_party_compatibility_export
+    _manifest_matches(
+        manifest,
+        POSTGRES_DEPLOYED_EXPORT_MANIFEST;
+        exact_indexes=true,
+    ) && return :deployed_first_party_composition
     _is_released_v1_subset(manifest) && return :released_1_0_export
     _is_preledger_hybrid(manifest) &&
         return :released_1_0_plus_preledger_bootstrap
@@ -1046,7 +1085,7 @@ function _assert_legacy_historical_keys!(conn)
     return nothing
 end
 
-function _upgrade_compatibility_export!(conn)
+function _assert_compatibility_required_values!(conn)
     invalid = _pg_dataframe(conn, """
         SELECT
           (SELECT count(*) FROM "public"."security_observations"
@@ -1062,6 +1101,25 @@ function _upgrade_compatibility_export!(conn)
             "compatibility export has null required values; " *
             "take a backup and repair explicitly",
         ))
+    return nothing
+end
+
+function _restore_compatibility_required_not_null!(conn)
+    _pg_command(conn, """
+        ALTER TABLE "public"."security_observations"
+          ALTER COLUMN ticker SET NOT NULL,
+          ALTER COLUMN is_active SET NOT NULL,
+          ALTER COLUMN join_status SET NOT NULL
+    """)
+    _pg_command(conn, """
+        ALTER TABLE "public"."fundamental_daily_metrics"
+          ALTER COLUMN fetched_at SET NOT NULL
+    """)
+    return nothing
+end
+
+function _upgrade_compatibility_export!(conn)
+    _assert_compatibility_required_values!(conn)
     _pg_command(conn, """
         ALTER TABLE "public"."historical_data"
           ALTER COLUMN close TYPE DOUBLE PRECISION,
@@ -1075,16 +1133,39 @@ function _upgrade_compatibility_export!(conn)
           ALTER COLUMN divcash TYPE DOUBLE PRECISION,
           ALTER COLUMN splitfactor TYPE DOUBLE PRECISION
     """)
+    _restore_compatibility_required_not_null!(conn)
+    return nothing
+end
+
+function _upgrade_deployed_export!(conn)
+    _assert_compatibility_required_values!(conn)
     _pg_command(conn, """
-        ALTER TABLE "public"."security_observations"
-          ALTER COLUMN ticker SET NOT NULL,
-          ALTER COLUMN is_active SET NOT NULL,
-          ALTER COLUMN join_status SET NOT NULL
+        CREATE UNIQUE INDEX tiingojulia_us_tickers_filtered_ticker_bridge
+        ON "public"."us_tickers_filtered" (ticker)
     """)
+    primary = _pg_dataframe(conn, """
+        SELECT constraint_name
+        FROM information_schema.table_constraints
+        WHERE table_schema = 'public'
+          AND table_name = 'us_tickers_filtered'
+          AND constraint_type = 'PRIMARY KEY'
+    """)
+    nrow(primary) == 1 || throw(PostgresMigrationError(
+        1,
+        "canonical_v1_baseline",
+        "deployed ticker export must have exactly one primary key constraint",
+    ))
+    constraint_name = quote_postgres_identifier(String(primary.constraint_name[1]))
+    _pg_command(
+        conn,
+        "ALTER TABLE \"public\".\"us_tickers_filtered\" " *
+        "DROP CONSTRAINT $constraint_name",
+    )
     _pg_command(conn, """
-        ALTER TABLE "public"."fundamental_daily_metrics"
-          ALTER COLUMN fetched_at SET NOT NULL
+        ALTER TABLE "public"."us_tickers_filtered"
+          ALTER COLUMN ticker DROP NOT NULL
     """)
+    _restore_compatibility_required_not_null!(conn)
     return nothing
 end
 
@@ -1099,6 +1180,8 @@ end
 function _apply_bootstrap_transition!(conn, catalog_entry::Symbol, manifest)
     catalog_entry == :first_party_compatibility_export &&
         _upgrade_compatibility_export!(conn)
+    catalog_entry == :deployed_first_party_composition &&
+        _upgrade_deployed_export!(conn)
     for statement in POSTGRES_TARGET_DDL
         _pg_command(conn, statement)
     end

--- a/test/test_postgres_integration.jl
+++ b/test/test_postgres_integration.jl
@@ -24,6 +24,8 @@ end
 
 function _pg_integration_cleanup(conn::LibPQ.Connection)
     for table in (
+        "tiingo_test_filtered_fk",
+        "filtered_stocks",
         "legacy_atomic_child",
         "legacy_atomic_second",
         "legacy_atomic_first",
@@ -170,6 +172,53 @@ function _pg_integration_create_compatibility_export(conn)
           (perma_ticker, metric_date, market_cap, fetched_at)
         VALUES ('PERMA', DATE '2024-02-03', 100.5, TIMESTAMP '2024-02-04 12:00:00')
     """)
+    return nothing
+end
+
+function _pg_integration_create_deployed_export(
+    conn;
+    primary_key_name::String="scheduler filtered ticker pkey",
+)
+    _pg_integration_create_compatibility_export(conn)
+    _pg_integration_command(conn, """
+        ALTER TABLE public.historical_data
+          ALTER COLUMN close TYPE DOUBLE PRECISION,
+          ALTER COLUMN high TYPE DOUBLE PRECISION,
+          ALTER COLUMN low TYPE DOUBLE PRECISION,
+          ALTER COLUMN open TYPE DOUBLE PRECISION,
+          ALTER COLUMN adjclose TYPE DOUBLE PRECISION,
+          ALTER COLUMN adjhigh TYPE DOUBLE PRECISION,
+          ALTER COLUMN adjlow TYPE DOUBLE PRECISION,
+          ALTER COLUMN adjopen TYPE DOUBLE PRECISION,
+          ALTER COLUMN divcash TYPE DOUBLE PRECISION,
+          ALTER COLUMN splitfactor TYPE DOUBLE PRECISION
+    """)
+    quoted_key = MigrationSchemaIntegration.quote_postgres_identifier(primary_key_name)
+    _pg_integration_command(conn, """
+        ALTER TABLE public.us_tickers_filtered
+          ALTER COLUMN ticker SET NOT NULL,
+          ADD CONSTRAINT $quoted_key PRIMARY KEY (ticker)
+    """)
+    _pg_integration_command(
+        conn,
+        "CREATE INDEX scheduler_filtered_assettype " *
+        "ON public.us_tickers_filtered (assettype)",
+    )
+    _pg_integration_command(
+        conn,
+        "CREATE INDEX scheduler_filtered_exchange " *
+        "ON public.us_tickers_filtered (exchange)",
+    )
+    _pg_integration_command(conn, """
+        CREATE TABLE public.filtered_stocks (
+            ticker VARCHAR PRIMARY KEY,
+            retained_value INTEGER NOT NULL
+        )
+    """)
+    _pg_integration_command(
+        conn,
+        "INSERT INTO public.filtered_stocks VALUES ('IGNORED', 7)",
+    )
     return nothing
 end
 
@@ -393,9 +442,173 @@ pg_connection_string = get(ENV, "TIINGO_TEST_PG_CONNECTION", "")
                     )
                     _pg_integration_command(pg, "DROP ROLE IF EXISTS $export_owner")
                 end
+
+                deployed_owner = "tiingo_test_deployed_migrator"
+                _pg_integration_cleanup(pg)
+                _pg_integration_command(pg, "DROP ROLE IF EXISTS $deployed_owner")
+                _pg_integration_command(pg, "CREATE ROLE $deployed_owner NOLOGIN")
+                deployed_tables = (
+                    "historical_data",
+                    "us_tickers_filtered",
+                    "security_observations",
+                    "fundamental_daily_metrics",
+                    "filtered_stocks",
+                )
+                try
+                    _pg_integration_command(
+                        pg,
+                        "GRANT CREATE ON SCHEMA public TO $deployed_owner",
+                    )
+                    _pg_integration_create_deployed_export(pg)
+                    for name in deployed_tables
+                        _pg_integration_command(
+                            pg,
+                            "ALTER TABLE public.$name OWNER TO $deployed_owner",
+                        )
+                    end
+                    @test_throws PostgresMigrationError migrate_postgres!(pg)
+                    _pg_integration_command(pg, "SET ROLE $deployed_owner")
+                    deployed_before = Dict(name => only(_pg_integration_query(
+                        pg,
+                        "SELECT md5(string_agg(to_jsonb(t)::text, '' " *
+                        "ORDER BY to_jsonb(t)::text)) AS fingerprint " *
+                        "FROM public.$name t",
+                    ).fingerprint) for name in deployed_tables)
+                    @test MigrationSchemaIntegration.classify_preledger_manifest(
+                        MigrationSchemaIntegration.inspect_postgres_manifest(pg),
+                    ) == :deployed_first_party_composition
+                    deployed_result = migrate_postgres!(pg)
+                    @test deployed_result.from_version == 0
+                    @test deployed_result.to_version == 1
+                    @test deployed_result.applied_versions == [1]
+                    deployed_after = Dict(name => only(_pg_integration_query(
+                        pg,
+                        "SELECT md5(string_agg(to_jsonb(t)::text, '' " *
+                        "ORDER BY to_jsonb(t)::text)) AS fingerprint " *
+                        "FROM public.$name t",
+                    ).fingerprint) for name in deployed_tables)
+                    @test deployed_after == deployed_before
+                    @test only(_pg_integration_query(
+                        pg,
+                        "SELECT is_nullable FROM information_schema.columns " *
+                        "WHERE table_schema = 'public' " *
+                        "AND table_name = 'us_tickers_filtered' " *
+                        "AND column_name = 'ticker'",
+                    ).is_nullable) == "YES"
+                    post_manifest =
+                        MigrationSchemaIntegration.inspect_postgres_manifest(pg)
+                    filtered_indexes = post_manifest.relations[
+                        "us_tickers_filtered"
+                    ].indexes
+                    @test !any(index -> index.primary, filtered_indexes)
+                    @test any(
+                        index -> index.unique && !index.primary &&
+                            index.columns == ("ticker",),
+                        filtered_indexes,
+                    )
+                    for columns in (("ticker",), ("assettype",), ("exchange",))
+                        @test any(
+                            index -> !index.unique && !index.primary &&
+                                index.columns == columns,
+                            filtered_indexes,
+                        )
+                    end
+                    _pg_integration_command(pg, """
+                        INSERT INTO public.us_tickers_filtered
+                          (ticker, exchange, assettype)
+                        VALUES ('EXPORTED', 'NYSE', 'Stock')
+                        ON CONFLICT (ticker) DO UPDATE
+                        SET exchange = EXCLUDED.exchange
+                    """)
+                    @test only(_pg_integration_query(
+                        pg,
+                        "SELECT exchange FROM public.us_tickers_filtered " *
+                        "WHERE ticker = 'EXPORTED'",
+                    ).exchange) == "NYSE"
+                    @test postgres_schema_version(pg) == 1
+                    @test migrate_postgres!(pg).applied_versions == Int[]
+                finally
+                    _pg_integration_command(pg, "RESET ROLE")
+                    _pg_integration_cleanup(pg)
+                    _pg_integration_command(
+                        pg,
+                        "REVOKE CREATE ON SCHEMA public FROM $deployed_owner",
+                    )
+                    _pg_integration_command(
+                        pg,
+                        "DROP ROLE IF EXISTS $deployed_owner",
+                    )
+                end
             end
 
             @testset "PostgreSQL migration fail-closed ledger and rollback" begin
+                _pg_integration_cleanup(pg)
+                _pg_integration_create_deployed_export(pg)
+                _pg_integration_command(
+                    pg,
+                    "UPDATE public.security_observations SET ticker = NULL",
+                )
+                _pg_integration_command(
+                    pg,
+                    "UPDATE public.fundamental_daily_metrics SET fetched_at = NULL",
+                )
+                @test_throws PostgresMigrationError migrate_postgres!(pg)
+                @test postgres_schema_version(pg) == 0
+                @test only(_pg_integration_query(
+                    pg,
+                    "SELECT is_nullable FROM information_schema.columns " *
+                    "WHERE table_schema = 'public' " *
+                    "AND table_name = 'us_tickers_filtered' " *
+                    "AND column_name = 'ticker'",
+                ).is_nullable) == "NO"
+                @test only(_pg_integration_query(
+                    pg,
+                    "SELECT count(*) FROM information_schema.table_constraints " *
+                    "WHERE table_schema = 'public' " *
+                    "AND table_name = 'us_tickers_filtered' " *
+                    "AND constraint_type = 'PRIMARY KEY'",
+                ).count) == 1
+                @test ismissing(only(_pg_integration_query(
+                    pg,
+                    "SELECT to_regclass(" *
+                    "'public.tiingojulia_us_tickers_filtered_ticker_bridge'" *
+                    ") AS relation",
+                ).relation))
+
+                _pg_integration_cleanup(pg)
+                _pg_integration_create_deployed_export(
+                    pg;
+                    primary_key_name="arbitrary Scheduler PK name",
+                )
+                _pg_integration_command(pg, """
+                    CREATE TABLE public.tiingo_test_filtered_fk (
+                        ticker VARCHAR REFERENCES public.us_tickers_filtered (ticker)
+                    )
+                """)
+                _pg_integration_command(
+                    pg,
+                    "INSERT INTO public.tiingo_test_filtered_fk VALUES ('EXPORTED')",
+                )
+                @test_throws PostgresMigrationError migrate_postgres!(pg)
+                @test postgres_schema_version(pg) == 0
+                @test only(_pg_integration_query(
+                    pg,
+                    "SELECT count(*) FROM information_schema.table_constraints " *
+                    "WHERE table_schema = 'public' " *
+                    "AND table_name = 'us_tickers_filtered' " *
+                    "AND constraint_type = 'PRIMARY KEY'",
+                ).count) == 1
+                @test ismissing(only(_pg_integration_query(
+                    pg,
+                    "SELECT to_regclass(" *
+                    "'public.tiingojulia_us_tickers_filtered_ticker_bridge'" *
+                    ") AS relation",
+                ).relation))
+                @test only(_pg_integration_query(
+                    pg,
+                    "SELECT ticker FROM public.tiingo_test_filtered_fk",
+                ).ticker) == "EXPORTED"
+
                 _pg_integration_cleanup(pg)
                 _pg_integration_create_compatibility_export(pg)
                 _pg_integration_command(

--- a/test/test_postgres_migrations.jl
+++ b/test/test_postgres_migrations.jl
@@ -79,6 +79,7 @@ end
         :fresh,
         :released_1_0_export,
         :first_party_compatibility_export,
+        :deployed_first_party_composition,
         :released_1_0_plus_preledger_bootstrap,
         :current_1_1_preledger,
     ])
@@ -107,6 +108,46 @@ end
           :float4
     @test compatibility_export.relations["security_observations"].columns[3].nullable
     @test compatibility_export.relations["fundamental_daily_metrics"].columns[7].nullable
+
+    deployed_export = deepcopy(MigrationSchema.POSTGRES_DEPLOYED_EXPORT_MANIFEST)
+    @test MigrationSchema.classify_preledger_manifest(deployed_export) ==
+          :deployed_first_party_composition
+    @test deployed_export.relations["historical_data"].columns[3].data_type ==
+          :float8
+    @test !deployed_export.relations["us_tickers_filtered"].columns[1].nullable
+    @test Set(MigrationSchema.semantic_index_key.(
+        deployed_export.relations["us_tickers_filtered"].indexes,
+    )) == Set([
+        (true, true, ("ticker",)),
+        (false, false, ("assettype",)),
+        (false, false, ("exchange",)),
+    ])
+
+    for near_miss in (
+        let manifest = deepcopy(deployed_export)
+            manifest.relations["us_tickers_filtered"].owner_matches_current_role = false
+            manifest
+        end,
+        let manifest = deepcopy(deployed_export)
+            manifest.relations["us_tickers_filtered"].columns[1] =
+                MigrationSchema.PostgresColumnManifest("ticker", :varchar, true)
+            manifest
+        end,
+        let manifest = deepcopy(deployed_export)
+            pop!(manifest.relations["us_tickers_filtered"].indexes)
+            manifest
+        end,
+        let manifest = deepcopy(deployed_export)
+            manifest.relations["us_tickers"] = deepcopy(
+                MigrationSchema.POSTGRES_TARGET_MANIFEST.relations["us_tickers"],
+            )
+            manifest
+        end,
+    )
+        @test_throws PostgresMigrationError MigrationSchema.classify_preledger_manifest(
+            near_miss,
+        )
+    end
 
     for near_miss in (
         let manifest = deepcopy(compatibility_export)


### PR DESCRIPTION
## Summary

- recognize the exact deployed four-table first-party export
- migrate `us_tickers_filtered` from its scheduler-added primary key to a unique bridge
- preserve scheduler `ON CONFLICT (ticker)` behavior while converging to canonical v1

## Root cause

The production database combines Tiingo's historical/Fundamentals exporter schema with scheduler-added ticker indexes. The pre-ledger classifier only accepted the individual first-party layouts, so it rejected this known composition before applying any migration.

## Safety

- require an exact catalog match and the table-owner role
- preflight required non-null values
- discover and quote the deployed primary-key constraint name
- run the transition transactionally without `CASCADE`
- roll back on dependent foreign keys or schema drift

## Validation

- PostgreSQL migration unit tests: 100/100
- PostgreSQL 17 integration tests: 233/233
- independent review: no P0-P3 findings
- `git diff --check`
