### PR TITLE
fix(postgres): preserve deployed ticker FK

### DIFF
--- a/src/db/migrations.jl
+++ b/src/db/migrations.jl
@@ -1139,22 +1139,128 @@ end
 
 function _upgrade_deployed_export!(conn)
     _assert_compatibility_required_values!(conn)
-    _pg_command(conn, """
-        CREATE UNIQUE INDEX tiingojulia_us_tickers_filtered_ticker_bridge
-        ON "public"."us_tickers_filtered" (ticker)
+    child_before_lock = _pg_dataframe(conn, """
+        SELECT pg_catalog.to_regclass('public.filtered_stocks') IS NOT NULL
+          AS present
     """)
+    has_filtered_stocks = Bool(child_before_lock.present[1])
+    lock_targets = has_filtered_stocks ?
+        "\"public\".\"us_tickers_filtered\", \"public\".\"filtered_stocks\"" :
+        "\"public\".\"us_tickers_filtered\""
+    _pg_command(conn, "LOCK TABLE $lock_targets IN ACCESS EXCLUSIVE MODE")
+
+    child_after_lock = _pg_dataframe(conn, """
+        SELECT pg_catalog.to_regclass('public.filtered_stocks') IS NOT NULL
+          AS present
+    """)
+    Bool(child_after_lock.present[1]) == has_filtered_stocks || throw(
+        PostgresMigrationError(
+            1,
+            "canonical_v1_baseline",
+            "filtered_stocks changed while acquiring migration locks; retry migration",
+        ),
+    )
+
     primary = _pg_dataframe(conn, """
-        SELECT constraint_name
-        FROM information_schema.table_constraints
-        WHERE table_schema = 'public'
-          AND table_name = 'us_tickers_filtered'
-          AND constraint_type = 'PRIMARY KEY'
+        SELECT primary_key.conindid::bigint AS index_oid,
+               primary_key.conname AS constraint_name
+        FROM pg_catalog.pg_constraint primary_key
+        JOIN pg_catalog.pg_class parent
+          ON parent.oid = primary_key.conrelid
+        JOIN pg_catalog.pg_namespace parent_namespace
+          ON parent_namespace.oid = parent.relnamespace
+        WHERE parent_namespace.nspname = 'public'
+          AND parent.relname = 'us_tickers_filtered'
+          AND primary_key.contype = 'p'
     """)
     nrow(primary) == 1 || throw(PostgresMigrationError(
         1,
         "canonical_v1_baseline",
-        "deployed ticker export must have exactly one primary key constraint",
+        "locked deployed ticker export must have exactly one primary key constraint",
     ))
+    index_oid = Int(primary.index_oid[1])
+
+    foreign_keys = _pg_dataframe(
+        conn,
+        """
+        SELECT COALESCE(
+                   foreign_key.conname = 'filtered_stocks_ticker_fkey'
+                   AND foreign_key.connamespace =
+                       'public'::regnamespace
+                   AND foreign_key.conkey =
+                       ARRAY[child_ticker.attnum]::smallint[]
+                   AND foreign_key.confkey =
+                       ARRAY[parent_ticker.attnum]::smallint[]
+                   AND foreign_key.convalidated
+                   AND NOT foreign_key.condeferrable
+                   AND NOT foreign_key.condeferred
+                   AND foreign_key.confmatchtype = 's'
+                   AND foreign_key.confupdtype = 'a'
+                   AND foreign_key.confdeltype = 'c'
+                   AND foreign_key.confdelsetcols IS NULL
+                   AND foreign_key.conparentid = 0
+                   AND foreign_key.conislocal
+                   AND foreign_key.coninhcount = 0
+                   AND foreign_key.connoinherit
+                   AND pg_catalog.obj_description(
+                       foreign_key.oid,
+                       'pg_constraint'
+                   ) IS NULL
+                   AND child_namespace.nspname = 'public'
+                   AND child.relname = 'filtered_stocks'
+                   AND parent_namespace.nspname = 'public'
+                   AND parent.relname = 'us_tickers_filtered',
+                   false
+               ) AS expected,
+               foreign_key.conname AS constraint_name
+        FROM pg_catalog.pg_constraint foreign_key
+        JOIN pg_catalog.pg_class child
+          ON child.oid = foreign_key.conrelid
+        JOIN pg_catalog.pg_namespace child_namespace
+          ON child_namespace.oid = child.relnamespace
+        JOIN pg_catalog.pg_attribute child_ticker
+          ON child_ticker.attrelid = child.oid
+         AND child_ticker.attname = 'ticker'
+         AND child_ticker.attnum > 0
+         AND NOT child_ticker.attisdropped
+        JOIN pg_catalog.pg_class parent
+          ON parent.oid = foreign_key.confrelid
+        JOIN pg_catalog.pg_namespace parent_namespace
+          ON parent_namespace.oid = parent.relnamespace
+        JOIN pg_catalog.pg_attribute parent_ticker
+          ON parent_ticker.attrelid = parent.oid
+         AND parent_ticker.attname = 'ticker'
+         AND parent_ticker.attnum > 0
+         AND NOT parent_ticker.attisdropped
+        WHERE foreign_key.contype = 'f'
+          AND foreign_key.conindid = \$1::oid
+        """,
+        Any[index_oid],
+    )
+    has_filtered_stocks_fk = nrow(foreign_keys) == 1 &&
+                             Bool(foreign_keys.expected[1])
+    (isempty(foreign_keys) || has_filtered_stocks_fk) || throw(
+        PostgresMigrationError(
+            1,
+            "canonical_v1_baseline",
+            "deployed ticker primary key has unsupported foreign-key dependencies",
+        ),
+    )
+
+    _pg_command(conn, """
+        CREATE UNIQUE INDEX tiingojulia_us_tickers_filtered_ticker_bridge
+        ON "public"."us_tickers_filtered" (ticker)
+    """)
+    if has_filtered_stocks_fk
+        foreign_key_name = quote_postgres_identifier(
+            String(foreign_keys.constraint_name[1]),
+        )
+        _pg_command(
+            conn,
+            "ALTER TABLE \"public\".\"filtered_stocks\" " *
+            "DROP CONSTRAINT $foreign_key_name",
+        )
+    end
     constraint_name = quote_postgres_identifier(String(primary.constraint_name[1]))
     _pg_command(
         conn,
@@ -1165,6 +1271,18 @@ function _upgrade_deployed_export!(conn)
         ALTER TABLE "public"."us_tickers_filtered"
           ALTER COLUMN ticker DROP NOT NULL
     """)
+    if has_filtered_stocks_fk
+        foreign_key_name = quote_postgres_identifier(
+            String(foreign_keys.constraint_name[1]),
+        )
+        _pg_command(conn, """
+            ALTER TABLE "public"."filtered_stocks"
+            ADD CONSTRAINT $foreign_key_name
+            FOREIGN KEY (ticker)
+            REFERENCES "public"."us_tickers_filtered" (ticker)
+            ON DELETE CASCADE
+        """)
+    end
     _restore_compatibility_required_not_null!(conn)
     return nothing
 end

--- a/test/test_postgres_integration.jl
+++ b/test/test_postgres_integration.jl
@@ -178,6 +178,8 @@ end
 function _pg_integration_create_deployed_export(
     conn;
     primary_key_name::String="scheduler filtered ticker pkey",
+    create_filtered_stocks::Bool=true,
+    foreign_key_delete_action::String="CASCADE",
 )
     _pg_integration_create_compatibility_export(conn)
     _pg_integration_command(conn, """
@@ -209,15 +211,21 @@ function _pg_integration_create_deployed_export(
         "CREATE INDEX scheduler_filtered_exchange " *
         "ON public.us_tickers_filtered (exchange)",
     )
+    create_filtered_stocks || return nothing
+    ticker_definition =
+        "ticker VARCHAR PRIMARY KEY " *
+        "CONSTRAINT filtered_stocks_ticker_fkey " *
+        "REFERENCES public.us_tickers_filtered (ticker) " *
+        "ON DELETE $foreign_key_delete_action"
     _pg_integration_command(conn, """
         CREATE TABLE public.filtered_stocks (
-            ticker VARCHAR PRIMARY KEY,
+            $ticker_definition,
             retained_value INTEGER NOT NULL
         )
     """)
     _pg_integration_command(
         conn,
-        "INSERT INTO public.filtered_stocks VALUES ('IGNORED', 7)",
+        "INSERT INTO public.filtered_stocks VALUES ('EXPORTED', 7)",
     )
     return nothing
 end
@@ -506,6 +514,26 @@ pg_connection_string = get(ENV, "TIINGO_TEST_PG_CONNECTION", "")
                             index.columns == ("ticker",),
                         filtered_indexes,
                     )
+                    deployed_fk = only(eachrow(_pg_integration_query(
+                        pg,
+                        """
+                        SELECT
+                            fk.conname,
+                            pg_get_constraintdef(fk.oid, false) AS definition,
+                            fk.conindid::regclass::text AS referenced_index,
+                            pg_get_userbyid(child.relowner) AS child_owner
+                        FROM pg_constraint fk
+                        JOIN pg_class child ON child.oid = fk.conrelid
+                        WHERE fk.conrelid = 'public.filtered_stocks'::regclass
+                          AND fk.contype = 'f'
+                        """,
+                    )))
+                    @test deployed_fk.conname == "filtered_stocks_ticker_fkey"
+                    @test deployed_fk.definition ==
+                          "FOREIGN KEY (ticker) REFERENCES us_tickers_filtered(ticker) ON DELETE CASCADE"
+                    @test deployed_fk.referenced_index ==
+                          "tiingojulia_us_tickers_filtered_ticker_bridge"
+                    @test deployed_fk.child_owner == deployed_owner
                     for columns in (("ticker",), ("assettype",), ("exchange",))
                         @test any(
                             index -> !index.unique && !index.primary &&
@@ -526,6 +554,36 @@ pg_connection_string = get(ENV, "TIINGO_TEST_PG_CONNECTION", "")
                         "WHERE ticker = 'EXPORTED'",
                     ).exchange) == "NYSE"
                     @test postgres_schema_version(pg) == 1
+                    @test migrate_postgres!(pg).applied_versions == Int[]
+                    _pg_integration_command(
+                        pg,
+                        "DELETE FROM public.us_tickers_filtered " *
+                        "WHERE ticker = 'EXPORTED'",
+                    )
+                    @test only(_pg_integration_query(
+                        pg,
+                        "SELECT count(*) FROM public.filtered_stocks " *
+                        "WHERE ticker = 'EXPORTED'",
+                    ).count) == 0
+
+                    _pg_integration_command(pg, "RESET ROLE")
+                    _pg_integration_cleanup(pg)
+                    _pg_integration_create_deployed_export(
+                        pg;
+                        create_filtered_stocks=false,
+                    )
+                    for name in deployed_tables[1:4]
+                        _pg_integration_command(
+                            pg,
+                            "ALTER TABLE public.$name OWNER TO $deployed_owner",
+                        )
+                    end
+                    _pg_integration_command(pg, "SET ROLE $deployed_owner")
+                    @test migrate_postgres!(pg).applied_versions == [1]
+                    @test ismissing(only(_pg_integration_query(
+                        pg,
+                        "SELECT to_regclass('public.filtered_stocks') AS relation",
+                    ).relation))
                     @test migrate_postgres!(pg).applied_versions == Int[]
                 finally
                     _pg_integration_command(pg, "RESET ROLE")
@@ -578,6 +636,27 @@ pg_connection_string = get(ENV, "TIINGO_TEST_PG_CONNECTION", "")
                 _pg_integration_cleanup(pg)
                 _pg_integration_create_deployed_export(
                     pg;
+                    foreign_key_delete_action="NO ACTION",
+                )
+                @test_throws PostgresMigrationError migrate_postgres!(pg)
+                @test postgres_schema_version(pg) == 0
+                wrong_action_fk = only(eachrow(_pg_integration_query(
+                    pg,
+                    """
+                    SELECT pg_get_constraintdef(oid, false) AS definition,
+                           conindid::regclass::text AS referenced_index
+                    FROM pg_constraint
+                    WHERE conname = 'filtered_stocks_ticker_fkey'
+                    """,
+                )))
+                @test wrong_action_fk.definition ==
+                      "FOREIGN KEY (ticker) REFERENCES us_tickers_filtered(ticker)"
+                @test wrong_action_fk.referenced_index ==
+                      "\"scheduler filtered ticker pkey\""
+
+                _pg_integration_cleanup(pg)
+                _pg_integration_create_deployed_export(
+                    pg;
                     primary_key_name="arbitrary Scheduler PK name",
                 )
                 _pg_integration_command(pg, """
@@ -608,6 +687,18 @@ pg_connection_string = get(ENV, "TIINGO_TEST_PG_CONNECTION", "")
                     pg,
                     "SELECT ticker FROM public.tiingo_test_filtered_fk",
                 ).ticker) == "EXPORTED"
+                @test only(_pg_integration_query(
+                    pg,
+                    "SELECT count(*) FROM pg_constraint " *
+                    "WHERE contype = 'f' AND confrelid = " *
+                    "'public.us_tickers_filtered'::regclass",
+                ).count) == 2
+                @test only(_pg_integration_query(
+                    pg,
+                    "SELECT conindid::regclass::text AS referenced_index " *
+                    "FROM pg_constraint " *
+                    "WHERE conname = 'filtered_stocks_ticker_fkey'",
+                ).referenced_index) == "\"arbitrary Scheduler PK name\""
 
                 _pg_integration_cleanup(pg)
                 _pg_integration_create_compatibility_export(pg)


### PR DESCRIPTION
## Summary

- preserve the deployed `filtered_stocks_ticker_fkey` during canonical v1 bootstrap
- rebind that exact first-party FK to the ticker unique bridge without `CASCADE`
- lock and re-read the relevant catalogs before mutation

## Root cause

The deployed database includes a first-party `filtered_stocks(ticker)` foreign key backed by the scheduler-added `us_tickers_filtered` primary-key index. PostgreSQL does not automatically rebind an existing FK when a replacement unique index is created, so dropping the old primary key failed and rolled the migration back.

## Safety

- accept only the observed validated, non-deferrable `ON DELETE CASCADE` FK
- explicitly drop and recreate only that known constraint
- use table locks and post-lock catalog reads to close concurrent-DDL races
- rely on native `DROP CONSTRAINT` RESTRICT for every unknown dependency
- never use `DROP ... CASCADE`

## Validation

- reproduced failure: PostgreSQL 17 `DependentObjectsStillExist`
- unit migration tests: 100/100
- PostgreSQL 17 integration tests: 247/247
- schema-safety, quality, and test reviews: no P0-P3 findings
- `git diff --check`
